### PR TITLE
[FEAT] : 공동 TitleAppBar 및 챌린지 페이지 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 *.log
 *.pyc
 *.swp
+.idea/
 .buildlog/
 .history
+
 
 
 

--- a/lib/components/challenge_item.dart
+++ b/lib/components/challenge_item.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:miyo/screens/challenge_detail_screen.dart';
+
+class ChallengeItem extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String location;
+
+  const ChallengeItem({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.location,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(color: Colors.white),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Color(0xffF0F2F5),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(icon, size: 28, color: Colors.black),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const SizedBox(height: 1),
+                Text(
+                  '주관: $location',
+                  style: TextStyle(fontSize: 14, color: Color(0xff61758A)),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.chevron_right, size: 37),
+            color: const Color(0xff757575),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const ChallengeDetailScreen(),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/challenge_mission.dart
+++ b/lib/components/challenge_mission.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+class ChallengeMission extends StatelessWidget {
+  final String title;
+  final int progress;
+  final int total;
+
+  const ChallengeMission({
+    super.key,
+    required this.title,
+    required this.progress,
+    required this.total,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    double progressValue = progress / total;
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(11),
+        border: Border.all(color: Color(0xffD6D6D6)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.normal,
+                ),
+              ),
+              Text('($progress/$total)', style: TextStyle(fontSize: 16)),
+            ],
+          ),
+          const SizedBox(height: 12),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: LinearProgressIndicator(
+              value: progressValue,
+              backgroundColor: Color(0xffD6D6D6),
+              valueColor: const AlwaysStoppedAnimation(Color(0xff00AA5D)),
+              minHeight: 13,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/title_appbar.dart
+++ b/lib/components/title_appbar.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+class TitleAppbar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final LeadingType? leadingType;
+  final VoidCallback? onLeadingPressed;
+  final List<Widget>? actions;
+
+  const TitleAppbar({
+    super.key,
+    required this.title,
+    this.leadingType = LeadingType.none,
+    this.onLeadingPressed,
+    this.actions,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      centerTitle: true,
+      automaticallyImplyLeading: false,
+      leading: _buildLeading(context),
+      title: Text(
+        title,
+        style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+      ),
+      actions: actions,
+      backgroundColor: Colors.white,
+      elevation: 0,
+      scrolledUnderElevation: 0,
+    );
+  }
+
+  Widget? _buildLeading(BuildContext context) {
+    if (leadingType == null) return null;
+
+    switch (leadingType!) {
+      case LeadingType.none:
+        return null;
+
+      case LeadingType.back:
+        return IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new),
+          onPressed: onLeadingPressed ?? () => Navigator.pop(context),
+        );
+
+      case LeadingType.close:
+        return IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: onLeadingPressed ?? () => Navigator.pop(context),
+        );
+    }
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}
+
+enum LeadingType {
+  none, // 기본
+  back, // 뒤로 가기
+  close, // 닫기
+}

--- a/lib/screens/challenge_all_screen.dart
+++ b/lib/screens/challenge_all_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:miyo/components/title_appbar.dart';
+
+class ChallengeAllScreen extends StatefulWidget {
+  const ChallengeAllScreen({super.key});
+
+  @override
+  State<ChallengeAllScreen> createState() => _ChallengeAllScreen();
+}
+
+class _ChallengeAllScreen extends State<ChallengeAllScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: TitleAppbar(title: '전체 챌린지', leadingType: LeadingType.back),
+      backgroundColor: Colors.white,
+    );
+  }
+}

--- a/lib/screens/challenge_detail_screen.dart
+++ b/lib/screens/challenge_detail_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:miyo/components/title_appbar.dart';
+
+class ChallengeDetailScreen extends StatefulWidget {
+  const ChallengeDetailScreen({super.key});
+
+  @override
+  State<ChallengeDetailScreen> createState() => _ChallengeDetailScreen();
+}
+
+class _ChallengeDetailScreen extends State<ChallengeDetailScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: TitleAppbar(title: '챌린지 정보', leadingType: LeadingType.close),
+      backgroundColor: Colors.white,
+    );
+  }
+}

--- a/lib/screens/challenge_ing_screen.dart
+++ b/lib/screens/challenge_ing_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:miyo/components/title_appbar.dart';
+
+class ChallengeIngScreen extends StatefulWidget {
+  const ChallengeIngScreen({super.key});
+
+  @override
+  State<ChallengeIngScreen> createState() => _ChallengeIngScreen();
+}
+
+class _ChallengeIngScreen extends State<ChallengeIngScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: TitleAppbar(title: '참가 중인 챌린지', leadingType: LeadingType.close),
+      backgroundColor: Colors.white,
+    );
+  }
+}

--- a/lib/screens/challenge_screen.dart
+++ b/lib/screens/challenge_screen.dart
@@ -1,4 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:miyo/components/title_appbar.dart';
+import 'package:miyo/components/challenge_mission.dart';
+import 'package:miyo/components/challenge_item.dart';
+import 'package:miyo/screens/challenge_all_screen.dart';
+import 'package:miyo/screens/challenge_ing_screen.dart';
 
 class ChallengeScreen extends StatefulWidget {
   const ChallengeScreen({super.key});
@@ -10,6 +15,100 @@ class ChallengeScreen extends StatefulWidget {
 class _ChallengeScreenState extends State<ChallengeScreen> {
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      appBar: const TitleAppbar(title: '챌린지'),
+      backgroundColor: Colors.white,
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 주간 미션 섹션
+              const Text(
+                '주간 미션',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 16),
+              const ChallengeMission(title: '제안 5번 하기', progress: 1, total: 5),
+              const SizedBox(height: 16),
+              const ChallengeMission(title: '공감 3번 하기', progress: 2, total: 3),
+
+              const SizedBox(height: 32),
+
+              // 참가 중인 챌린지 섹션
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    '참가 중인 챌린지',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => const ChallengeIngScreen(),
+                        ),
+                      );
+                    },
+                    child: const Text(
+                      '더보기',
+                      style: TextStyle(color: Color(0xff61758A), fontSize: 14),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              const ChallengeItem(
+                icon: Icons.park_rounded,
+                title: '2026 우리 동네 공원 상상하기',
+                location: '서울시',
+              ),
+
+              const SizedBox(height: 50),
+
+              // 전체 챌린지 섹션
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    '전체 챌린지',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => const ChallengeAllScreen(),
+                        ),
+                      );
+                    },
+                    child: const Text(
+                      '더보기',
+                      style: TextStyle(color: Color(0xff61758A), fontSize: 14),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              const ChallengeItem(
+                icon: Icons.apartment_rounded,
+                title: '2026 성북구 편의시설 상상하기',
+                location: '성북구',
+              ),
+              const SizedBox(height: 12),
+              const ChallengeItem(
+                icon: Icons.water,
+                title: '2026 한강변 상상하기',
+                location: '서울시',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## 📝작업 내용
#8 
- gitignore 파일 수정 : /idea 디렉토리 추가
- 공동 TitleAppBar 제작 : components/title_appbar.dart
   - LeadingType 정의 : 기본(none), 뒤로가기(back), 닫기(close)
   - 사용시 LeadingType의 값을 넣어주면 leading 아이콘 넣어집니다.
- 챌린지 컴포넌트 추가 : components/challenge_item.dart
- 챌린지 주간 미션 컴포넌트 추가 : components/challenge_mission.dart
- 챌린지 기본 페이지 제작
- 챌린지 관련 세부 페이지 제작
   - challenge_ing_screen.dart : 참가 중인 챌린지 페이지
   - challenge_all_screen.dart : 전체 챌린지 페이지
   - challenge_detail_screen.dart : 챌린지 상세 페이지

### 스크린샷
<img width=45% alt="챌린지_기본" src="https://github.com/user-attachments/assets/7a88d14b-24d9-43a2-9501-183b9512cf05" /> <img width=45% alt="챌린지_참가중" src="https://github.com/user-attachments/assets/750dfbc4-bee9-446f-8d19-3b0d639babd1" />
<img width=45% alt="챌린지_전체" src="https://github.com/user-attachments/assets/b36874a4-e6f5-4038-a369-7a64bda53db1" /> <img width=45% alt="챌린지_상세" src="https://github.com/user-attachments/assets/85fcd421-45ba-4055-9780-a5a1d8b95df3" />

## 💬리뷰 요구사항(선택)
현재 챌린지 참가 중, 전체, 상세 페이지에는 topNavBar가 안 보이도록 해두었습니다. 
이 페이지에서는 보이지 않는 것이 원래 기획의도였으나, 혹시 이 페이지에서도 tobNavBar가 보여야한다면 말씀부탁드립니다. 
