### PR TITLE
[FEAT] : 챌린지 참가 중 페이지 추가 & [MODIFY] : 챌린지 제목 컴포넌트 수정

### DIFF
--- a/lib/components/challenge_item.dart
+++ b/lib/components/challenge_item.dart
@@ -2,13 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:miyo/screens/challenge_detail_screen.dart';
 
 class ChallengeItem extends StatelessWidget {
-  final IconData icon;
+  // final IconData icon;
+  final CategoryType? categoryType;
   final String title;
   final String location;
 
   const ChallengeItem({
     super.key,
-    required this.icon,
+    required this.categoryType,
     required this.title,
     required this.location,
   });
@@ -25,7 +26,7 @@ class ChallengeItem extends StatelessWidget {
               color: Color(0xffF0F2F5),
               borderRadius: BorderRadius.circular(8),
             ),
-            child: Icon(icon, size: 28, color: Colors.black),
+            child: _buildIcon(context),
           ),
           const SizedBox(width: 16),
           Expanded(
@@ -63,4 +64,41 @@ class ChallengeItem extends StatelessWidget {
       ),
     );
   }
+
+  Widget? _buildIcon(BuildContext context) {
+    if (categoryType == null) return null;
+
+    switch (categoryType!) {
+      case CategoryType.NaturePark:
+        return Icon(Icons.park_rounded);
+
+      case CategoryType.CultureArts:
+        return Icon(Icons.color_lens);
+
+      case CategoryType.Transport:
+        return Icon(Icons.directions_bus);
+
+      case CategoryType.Life:
+        return Icon(Icons.house_rounded);
+
+      case CategoryType.Commercial:
+        return Icon(Icons.attach_money_rounded);
+
+      case CategoryType.NightLandscape:
+        return Icon(Icons.landscape_rounded);
+
+      case CategoryType.EnvironSustain:
+        return Icon(Icons.eco_rounded);
+    }
+  }
+}
+
+enum CategoryType {
+  NaturePark, // 자연/공원
+  CultureArts, // 문화/예술
+  Transport, // 교통/이동
+  Life, // 주거/생활
+  Commercial, // 상권/시장
+  NightLandscape, // 야간/경관
+  EnvironSustain, // 환경/지속가능
 }

--- a/lib/screens/challenge_ing_screen.dart
+++ b/lib/screens/challenge_ing_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:miyo/components/challenge_item.dart';
 import 'package:miyo/components/title_appbar.dart';
 
 class ChallengeIngScreen extends StatefulWidget {
@@ -14,6 +15,33 @@ class _ChallengeIngScreen extends State<ChallengeIngScreen> {
     return Scaffold(
       appBar: TitleAppbar(title: '참가 중인 챌린지', leadingType: LeadingType.close),
       backgroundColor: Colors.white,
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const ChallengeItem(
+                categoryType: CategoryType.NaturePark,
+                title: "2026 우리 동네 공원 상상하기",
+                location: "서울시",
+              ),
+              const SizedBox(height: 16),
+              const ChallengeItem(
+                categoryType: CategoryType.Life,
+                title: "2026 성북구 편의시설 상상하기",
+                location: "성북구",
+              ),
+              const SizedBox(height: 16),
+              const ChallengeItem(
+                categoryType: CategoryType.EnvironSustain,
+                title: "2026 한강변 상상하기",
+                location: "서울시",
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/challenge_screen.dart
+++ b/lib/screens/challenge_screen.dart
@@ -62,7 +62,7 @@ class _ChallengeScreenState extends State<ChallengeScreen> {
               ),
               const SizedBox(height: 12),
               const ChallengeItem(
-                icon: Icons.park_rounded,
+                categoryType: CategoryType.NaturePark,
                 title: '2026 우리 동네 공원 상상하기',
                 location: '서울시',
               ),
@@ -95,13 +95,13 @@ class _ChallengeScreenState extends State<ChallengeScreen> {
               ),
               const SizedBox(height: 12),
               const ChallengeItem(
-                icon: Icons.apartment_rounded,
+                categoryType: CategoryType.Life,
                 title: '2026 성북구 편의시설 상상하기',
                 location: '성북구',
               ),
               const SizedBox(height: 12),
               const ChallengeItem(
-                icon: Icons.water,
+                categoryType: CategoryType.EnvironSustain,
                 title: '2026 한강변 상상하기',
                 location: '서울시',
               ),


### PR DESCRIPTION
## 📝 작업 내용
#8 

- 챌린지 제목 컴포넌트를 수정했습니다.
   CategoryType을 선언하였고, 카테고리별로 임시 아이콘을 지정했습니다.
   컴포넌트 사용시 카테고리 항목을 파라미터로 주면 아이콘이 자동으로 지정됩니다. 
- 챌린지 참가 중 페이지를 추가했습니다.

### 스크린샷 (선택)
<img width="360" height="206" alt="image" src="https://github.com/user-attachments/assets/394e8064-4212-4ead-92d6-5c7c2bc41fbc" />
<img width="1080" height="2340" alt="챌린지_카테고리아이콘" src="https://github.com/user-attachments/assets/83759226-2999-42b0-af37-77f0e72c6a5d" />

