### PR TITLE
[FEAT] : 앱 설정 페이지 추가

### DIFF
--- a/lib/screens/settings/profile_settings_screen.dart
+++ b/lib/screens/settings/profile_settings_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:miyo/components/title_appbar.dart';
+import 'package:miyo/screens/settings/settings_account_section.dart';
+import 'package:miyo/screens/settings/settings_application_section.dart';
+import 'package:miyo/screens/settings/settings_myactivity_section.dart';
+
+class ProfileSettingScreen extends StatefulWidget {
+  const ProfileSettingScreen({super.key});
+
+  @override
+  State<ProfileSettingScreen> createState() => _ProfileSettingScreenState();
+}
+
+class _ProfileSettingScreenState extends State<ProfileSettingScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.of(context).size.height;
+
+    return Scaffold(
+      appBar: TitleAppbar(title: "앱 설정", leadingType: LeadingType.back),
+      backgroundColor: Colors.white,
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 계정 섹션
+              SettingsAccountSection(),
+              // 내 활동 섹션
+              SizedBox(height: height * 0.02),
+              SettingsMyactivitySection(),
+              // 어플리케이션 섹션
+              SizedBox(height: height * 0.02),
+              SettingsApplicationSection(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/settings_account_section.dart
+++ b/lib/screens/settings/settings_account_section.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:miyo/screens/settings/settings_button.dart';
+import 'package:miyo/screens/settings/settings_challengeprofile_screen.dart';
+import 'package:miyo/screens/settings/settings_logininfo_screen.dart';
+
+class SettingsAccountSection extends StatelessWidget {
+  const SettingsAccountSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.of(context).size.height;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '계정',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        SizedBox(height: height * 0.01),
+        SettingButton(
+          label: "로그인 정보",
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => const SettingsLoginInfoScreen(),
+              ),
+            );
+          },
+        ),
+        SettingButton(
+          label: "챌린지 프로필 관리",
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => const SettingsChallengeProfileScreen(),
+              ),
+            );
+          },
+        ),
+        SettingButton(
+          label: "로그아웃",
+          showTrailingIcon: false,
+          textColor: Color(0xffE60000),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/settings/settings_application_section.dart
+++ b/lib/screens/settings/settings_application_section.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:miyo/screens/settings/settings_button.dart';
+
+class SettingsApplicationSection extends StatelessWidget {
+  const SettingsApplicationSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.of(context).size.height;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          "어플리케이션",
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        SizedBox(height: height * 0.01),
+        SettingButton(label: "알림 설정"),
+        SettingButton(label: "언어"),
+      ],
+    );
+  }
+}

--- a/lib/screens/settings/settings_button.dart
+++ b/lib/screens/settings/settings_button.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+class SettingButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onTap;
+  final bool showTrailingIcon;
+  final Color? textColor;
+
+  const SettingButton({
+    super.key,
+    required this.label,
+    this.onTap,
+    this.showTrailingIcon = true,
+    this.textColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Color(0xffDBE0E5), width: 1),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 16, 10, 16),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.w600,
+                      color: textColor ?? Colors.black,
+                    ),
+                  ),
+                ),
+                if (showTrailingIcon)
+                  Icon(Icons.chevron_right, color: Color(0xff757575), size: 25),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/settings_challengeprofile_screen.dart
+++ b/lib/screens/settings/settings_challengeprofile_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:miyo/components/title_appbar.dart';
+
+class SettingsChallengeProfileScreen extends StatefulWidget {
+  const SettingsChallengeProfileScreen({super.key});
+
+  @override
+  State<SettingsChallengeProfileScreen> createState() =>
+      _SettingsChallengeProfileScreenState();
+}
+
+class _SettingsChallengeProfileScreenState
+    extends State<SettingsChallengeProfileScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: TitleAppbar(title: "챌린지 프로필 관리", leadingType: LeadingType.close),
+      backgroundColor: Colors.white,
+    );
+  }
+}

--- a/lib/screens/settings/settings_logininfo_screen.dart
+++ b/lib/screens/settings/settings_logininfo_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:miyo/components/title_appbar.dart';
+
+class SettingsLoginInfoScreen extends StatefulWidget {
+  const SettingsLoginInfoScreen({super.key});
+
+  @override
+  State<SettingsLoginInfoScreen> createState() =>
+      _SettingsLoginInfoScreenState();
+}
+
+class _SettingsLoginInfoScreenState extends State<SettingsLoginInfoScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: TitleAppbar(title: "로그인 정보", leadingType: LeadingType.close),
+      backgroundColor: Colors.white,
+    );
+  }
+}

--- a/lib/screens/settings/settings_myactivity_section.dart
+++ b/lib/screens/settings/settings_myactivity_section.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:miyo/screens/settings/settings_button.dart';
+
+class SettingsMyactivitySection extends StatelessWidget {
+  const SettingsMyactivitySection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.of(context).size.height;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          "내 활동",
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        SizedBox(height: height * 0.01),
+        SettingButton(label: "내가 쓴 글"),
+        SettingButton(label: "내가 좋아요한 글"),
+        SettingButton(label: "내가 쓴 댓글"),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용
#8
- 앱 설정 페이지를 추가했습니다.
- 로그인 정보 페이지, 챌린지 프로필 관리 페이지를 추가하여 템플릿을 생성했습니다. 

### 스크린샷 (선택)
<img width=32% alt="앱설정" src="https://github.com/user-attachments/assets/b6942828-24ab-4826-8bde-e6f7f1709b8b" />
<img width=32% alt="앱설정_로그인정보" src="https://github.com/user-attachments/assets/bbc37575-f4e7-4601-b79c-9a3d35861898" />
<img width=32% alt="앱설정_챌린지프로필관리" src="https://github.com/user-attachments/assets/384234ae-4203-42eb-8345-676a39ffa08d" />
