### PR TITLE
[FEAT] : 회원가입 버튼 수정 및 회원가입 완료 UI 구현

### DIFF
--- a/lib/screens/onboarding/signup_button.dart
+++ b/lib/screens/onboarding/signup_button.dart
@@ -453,6 +453,7 @@ class _SignupButtonState extends State<SignupButton> {
           height: height * 0.06,
           width: width * 0.8,
           child: TextField(
+            obscureText: true,
             controller: passwordVerificationController,
             style: TextStyle(
               fontSize: 15,

--- a/lib/screens/onboarding/signup_button.dart
+++ b/lib/screens/onboarding/signup_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:miyo/screens/onboarding/login_screen.dart';
+import 'package:miyo/screens/onboarding/signup_complete_screen.dart';
 
 class SignupButton extends StatefulWidget {
   const SignupButton({super.key});
@@ -505,7 +506,7 @@ class _SignupButtonState extends State<SignupButton> {
             ),
             onPressed: _isAllValid ? () {
               Navigator.push(
-                context, MaterialPageRoute(builder: (context) => LoginScreen()));
+                context, MaterialPageRoute(builder: (context) => SignupCompleteScreen()));
             } : null,
             child: Text(
               '회원가입',

--- a/lib/screens/onboarding/signup_button.dart
+++ b/lib/screens/onboarding/signup_button.dart
@@ -183,7 +183,7 @@ class _SignupButtonState extends State<SignupButton> {
           children: [
             SizedBox(
               height: height * 0.06,
-              width: width * 0.51,
+              width: width * 0.56,
               child: TextField(
                 controller: idController,
                 style: TextStyle(
@@ -210,17 +210,18 @@ class _SignupButtonState extends State<SignupButton> {
             SizedBox(width: width * 0.02),
             SizedBox(
               height: height * 0.06,
-              width: width * 0.27,
+              width: width * 0.22,
               child: ElevatedButton(
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Color(0xff00AA5D),
+                  padding: EdgeInsets.symmetric(horizontal: 2, vertical: 0),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
                   ),
                 ),
                 onPressed: () {
-                  print('아이디 중복 확인');                
-                }, 
+                  print('아이디 중복 확인');
+                },
                 child: Text(
                   '중복 확인',
                   style: TextStyle(
@@ -257,7 +258,7 @@ class _SignupButtonState extends State<SignupButton> {
           children: [
             SizedBox(
               height: height * 0.06,
-              width: width * 0.51,
+              width: width * 0.56,
               child: TextField(
                 controller: emailController,
                 style: TextStyle(
@@ -284,17 +285,18 @@ class _SignupButtonState extends State<SignupButton> {
             SizedBox(width: width * 0.02),
             SizedBox(
               height: height * 0.06,
-              width: width * 0.27,
+              width: width * 0.22,
               child: ElevatedButton(
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Color(0xff00AA5D),
+                  padding: EdgeInsets.symmetric(horizontal: 2, vertical: 0),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
                   ),
                 ),
                 onPressed: () {
-                  print('코드 전송');                
-                }, 
+                  print('코드 전송');
+                },
                 child: Text(
                   '코드 전송',
                   style: TextStyle(
@@ -331,7 +333,7 @@ class _SignupButtonState extends State<SignupButton> {
           children: [
             SizedBox(
               height: height * 0.06,
-              width: width * 0.4,
+              width: width * 0.46,
               child: TextField(
                 controller: verificationCodeController,
                 style: TextStyle(
@@ -358,17 +360,18 @@ class _SignupButtonState extends State<SignupButton> {
             SizedBox(width: width * 0.02),
             SizedBox(
               height: height * 0.06,
-              width: width * 0.38,
+              width: width * 0.32,
               child: ElevatedButton(
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Color(0xff00AA5D),
+                  padding: EdgeInsets.symmetric(horizontal: 2, vertical: 0),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
                   ),
                 ),
                 onPressed: () {
-                  print('인증 코드 입력');                
-                }, 
+                  print('인증 코드 입력');
+                },
                 child: Text(
                   '이메일 인증하기',
                   style: TextStyle(

--- a/lib/screens/onboarding/signup_complete_screen.dart
+++ b/lib/screens/onboarding/signup_complete_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+class SignupCompleteScreen extends StatefulWidget {
+  const SignupCompleteScreen({super.key});
+
+  @override
+  State<SignupCompleteScreen> createState() => _SignupCompleteScreenState();
+}
+
+class _SignupCompleteScreenState extends State<SignupCompleteScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.of(context).size.height;
+    final width = MediaQuery.of(context).size.width;
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('회원가입이 완료되었습니다!',
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            SizedBox(height: height * 0.05),
+            Icon(
+              Icons.check_circle, 
+              size: 100, 
+              color: Color(0xff00AA5D)
+            ),
+            SizedBox(height: height * 0.05),
+            SizedBox(
+              height: height * 0.06,
+              width: width * 0.8,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Color(0xff00AA5D),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                onPressed: () {
+                  Navigator.popUntil(context, (route) => route.isFirst); 
+                  // 초기 화면으로 돌아가기 회원가입 -> 로그인 절차라면. 아니면 그냥 홈화면으로 이동해도 됨
+                },
+                child: Text(
+                  '회원가입 완료',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/onboarding/signup_complete_screen.dart
+++ b/lib/screens/onboarding/signup_complete_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:miyo/screens/onboarding/login_screen.dart';
 
 class SignupCompleteScreen extends StatefulWidget {
   const SignupCompleteScreen({super.key});
@@ -42,8 +43,11 @@ class _SignupCompleteScreenState extends State<SignupCompleteScreen> {
                   ),
                 ),
                 onPressed: () {
-                  Navigator.popUntil(context, (route) => route.isFirst); 
-                  // 초기 화면으로 돌아가기 회원가입 -> 로그인 절차라면. 아니면 그냥 홈화면으로 이동해도 됨
+                  Navigator.pushAndRemoveUntil(
+                    context,
+                    MaterialPageRoute(builder: (context) => const LoginScreen()),
+                    (route) => route.isFirst,
+                  );
                 },
                 child: Text(
                   '회원가입 완료',


### PR DESCRIPTION
## 📝작업 내용

회원가입 버튼 padding 수정
회원가입 완료 UI 구현

### 스크린샷 (선택)

<img width="300" height="630" alt="image" src="https://github.com/user-attachments/assets/a9f7637e-608d-4d24-9be7-c084e238f9de" />
<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/5714f7bd-9500-4467-aed0-3fae5d502309" />



## 💬리뷰 요구사항(선택)

버튼 패딩 요정도면 괜찮을까요??
회원가입 완료 버튼 누르면 초기화면으로 넘어가게 해놨는데
회원가입 -> 로그인
회원가입 -> 홈
어떤걸로 하기로 했었죵..? 필요하면 수정할게요!
