### PR TITLE
[FIX] : 앱 설정 화면 - 내 활동 관련 섹션 삭제

### DIFF
--- a/lib/screens/settings/profile_settings_screen.dart
+++ b/lib/screens/settings/profile_settings_screen.dart
@@ -27,9 +27,9 @@ class _ProfileSettingScreenState extends State<ProfileSettingScreen> {
             children: [
               // 계정 섹션
               SettingsAccountSection(),
-              // 내 활동 섹션
-              SizedBox(height: height * 0.02),
-              SettingsMyactivitySection(),
+              // // 내 활동 섹션
+              // SizedBox(height: height * 0.02),
+              // SettingsMyactivitySection(),
               // 어플리케이션 섹션
               SizedBox(height: height * 0.02),
               SettingsApplicationSection(),


### PR DESCRIPTION
## 📝작업 내용
#8 
앱 설정 화면에서 내 활동 관련 섹션을 삭제했습니다 (프로필 메인 화면이랑 겹치기 때문)

<img width="1080" height="2340" alt="앱설정" src="https://github.com/user-attachments/assets/23ffad04-59a3-4e53-bc12-09b32521fd9d" />
