### PR TITLE
[FEAT] : 챌린지 페이지 API 연동

### DIFF
--- a/lib/components/challenge_item.dart
+++ b/lib/components/challenge_item.dart
@@ -6,6 +6,7 @@ class ChallengeItem extends StatelessWidget {
   final String title;
   final String location;
   final bool isTitleBox;
+  final int? contestId;
 
   const ChallengeItem({
     super.key,
@@ -13,6 +14,7 @@ class ChallengeItem extends StatelessWidget {
     required this.title,
     required this.location,
     this.isTitleBox = false,
+    this.contestId,
   });
 
   @override
@@ -54,12 +56,16 @@ class ChallengeItem extends StatelessWidget {
               icon: const Icon(Icons.chevron_right, size: 37),
               color: const Color(0xff757575),
               onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const ChallengeDetailScreen(),
-                  ),
-                );
+                if (contestId != null) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => ChallengeDetailScreen(
+                        contestId: contestId!,
+                      ),
+                    ),
+                  );
+                }
               },
             ),
         ],

--- a/lib/components/challenge_item.dart
+++ b/lib/components/challenge_item.dart
@@ -7,6 +7,7 @@ class ChallengeItem extends StatelessWidget {
   final String location;
   final bool isTitleBox;
   final int? contestId;
+  final bool showArrow; // 화살표 표시 여부
 
   const ChallengeItem({
     super.key,
@@ -15,6 +16,7 @@ class ChallengeItem extends StatelessWidget {
     required this.location,
     this.isTitleBox = false,
     this.contestId,
+    this.showArrow = true, // 기본값: 화살표 표시
   });
 
   @override
@@ -51,7 +53,7 @@ class ChallengeItem extends StatelessWidget {
               ],
             ),
           ),
-          if (!isTitleBox)
+          if (!isTitleBox && showArrow)
             IconButton(
               icon: const Icon(Icons.chevron_right, size: 37),
               color: const Color(0xff757575),

--- a/lib/data/services/challenge_service.dart
+++ b/lib/data/services/challenge_service.dart
@@ -316,15 +316,52 @@ class ChallengeService {
       print('Response Data: ${e.response?.data}');
       print('Error Message: ${e.message}');
 
-      if (e.response?.statusCode == 404) {
-        throw Exception('챌린지를 찾을 수 없습니다.');
+      if (e.response?.statusCode == 400) {
+        throw Exception('이미 참가한 공모전입니다.');
       } else if (e.response?.statusCode == 401) {
         throw Exception('인증이 필요합니다. 로그인 후 다시 시도해주세요.');
-      } else if (e.response?.statusCode == 403) {
-        throw Exception('권한이 없습니다.');
-      } else if (e.response?.statusCode == 500) {
-        final errorMsg = e.response?.data?.toString() ?? '서버 오류가 발생했습니다.';
-        throw Exception('서버 오류: $errorMsg');
+      } else if (e.response?.statusCode == 404) {
+        throw Exception('공모전을 찾을 수 없습니다.');
+      }
+      throw Exception(
+        '네트워크 오류: ${e.message} (Status: ${e.response?.statusCode})',
+      );
+    } catch (e) {
+      print('❌ Unexpected Error: $e');
+      rethrow;
+    }
+  }
+
+  /// 챌린지 참가
+  ///
+  /// [contestId]: 참가할 챌린지 ID
+  Future<void> joinContest({required int contestId}) async {
+    try {
+      // 개발 모드: 더미 응답
+      if (ApiService.isDevelopmentMode) {
+        await Future.delayed(const Duration(milliseconds: 500));
+        return;
+      }
+      final response = await _apiService.post('/v0/contests/$contestId/join');
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        print('✅ 챌린지 참가 성공: contestId=$contestId');
+        return;
+      } else {
+        throw Exception('챌린지 참가에 실패했습니다. (Status: ${response.statusCode})');
+      }
+    } on DioException catch (e) {
+      print('❌ DioException 발생:');
+      print('Status Code: ${e.response?.statusCode}');
+      print('Response Data: ${e.response?.data}');
+      print('Error Message: ${e.message}');
+
+      if (e.response?.statusCode == 400) {
+        throw Exception('이미 참가한 공모전입니다.');
+      } else if (e.response?.statusCode == 401) {
+        throw Exception('인증 실패');
+      } else if (e.response?.statusCode == 404) {
+        throw Exception('공모전을 찾을 수 없습니다.');
       }
       throw Exception(
         '네트워크 오류: ${e.message} (Status: ${e.response?.statusCode})',

--- a/lib/data/services/challenge_service.dart
+++ b/lib/data/services/challenge_service.dart
@@ -290,4 +290,48 @@ class ChallengeService {
       rethrow;
     }
   }
+
+  /// contestId로 챌린지 상세 정보 조회
+  ///
+  /// [contestId]: 조회할 챌린지 ID
+  Future<Map<String, dynamic>> getContestById({required int contestId}) async {
+    try {
+      // 프로덕션 모드: 실제 API 호출
+      // Spring Boot 엔드포인트: GET /v0/contests/{contestId}
+      final response = await _apiService.get('/v0/contests/$contestId');
+
+      if (response.statusCode == 200) {
+        final data = response.data as Map<String, dynamic>;
+        print('✅ getContestById API 응답:');
+        print('  - contestId: ${data['contestId']}');
+        print('  - title: ${data['title']}');
+        print('  - 전체 데이터: $data');
+        return data;
+      } else {
+        throw Exception('챌린지 조회에 실패했습니다. (Status: ${response.statusCode})');
+      }
+    } on DioException catch (e) {
+      print('❌ DioException 발생:');
+      print('Status Code: ${e.response?.statusCode}');
+      print('Response Data: ${e.response?.data}');
+      print('Error Message: ${e.message}');
+
+      if (e.response?.statusCode == 404) {
+        throw Exception('챌린지를 찾을 수 없습니다.');
+      } else if (e.response?.statusCode == 401) {
+        throw Exception('인증이 필요합니다. 로그인 후 다시 시도해주세요.');
+      } else if (e.response?.statusCode == 403) {
+        throw Exception('권한이 없습니다.');
+      } else if (e.response?.statusCode == 500) {
+        final errorMsg = e.response?.data?.toString() ?? '서버 오류가 발생했습니다.';
+        throw Exception('서버 오류: $errorMsg');
+      }
+      throw Exception(
+        '네트워크 오류: ${e.message} (Status: ${e.response?.statusCode})',
+      );
+    } catch (e) {
+      print('❌ Unexpected Error: $e');
+      rethrow;
+    }
+  }
 }

--- a/lib/data/services/post_service.dart
+++ b/lib/data/services/post_service.dart
@@ -97,6 +97,72 @@ class PostService {
     }
   }
 
+  /// 챌린지 내 제안 글 게시글 작성
+  ///
+  /// [contestId]: 챌린지(공모전) ID
+  /// [title]: 게시글 제목
+  /// [content]: 게시글 내용
+  /// [category]: 카테고리 (NATURE 등)
+  /// [imagePath]: 이미지 파일 경로
+  Future<Map<String, dynamic>> createContestPost({
+    required int contestId,
+    required String title,
+    required String content,
+    required String category,
+    required String imagePath,
+  }) async {
+    try {
+      // 프로덕션 모드: 실제 API 호출
+      // Spring Boot 엔드포인트: POST /v0/contests/{contestId}/posts
+      final response = await _apiService.post(
+        '/v0/contests/$contestId/posts',
+        data: {
+          'title': title,
+          'content': content,
+          'category': category,
+          'imagePath': imagePath,
+        },
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final data = response.data as Map<String, dynamic>;
+        print('✅ createPost API 응답:');
+        print('  - postId: ${data['postId']}');
+        print('  - userId: ${data['userId']}');
+        print('  - userNickname: ${data['userNickname']}');
+        print('  - title: ${data['title']}');
+        print('  - 전체 데이터: $data');
+        return data;
+      } else {
+        throw Exception('게시글 작성에 실패했습니다. (Status: ${response.statusCode})');
+      }
+    } on DioException catch (e) {
+      print('❌ DioException 발생:');
+      print('Status Code: ${e.response?.statusCode}');
+      print('Response Data: ${e.response?.data}');
+      print('Error Message: ${e.message}');
+      print('Request Data: ${e.requestOptions.data}');
+
+      if (e.response?.statusCode == 400) {
+        final errorMsg = e.response?.data?.toString() ?? '잘못된 요청입니다.';
+        throw Exception('잘못된 요청: $errorMsg');
+      } else if (e.response?.statusCode == 401) {
+        throw Exception('인증이 필요합니다. 로그인 후 다시 시도해주세요.');
+      } else if (e.response?.statusCode == 403) {
+        throw Exception('권한이 없습니다.');
+      } else if (e.response?.statusCode == 500) {
+        final errorMsg = e.response?.data?.toString() ?? '서버 오류가 발생했습니다.';
+        throw Exception('서버 오류: $errorMsg');
+      }
+      throw Exception(
+        '네트워크 오류: ${e.message} (Status: ${e.response?.statusCode})',
+      );
+    } catch (e) {
+      print('❌ Unexpected Error: $e');
+      rethrow;
+    }
+  }
+
   /// 내 게시글 목록 조회
   ///
   /// [categories]: 카테고리 필터 (옵션)
@@ -264,7 +330,9 @@ class PostService {
     int size = 20,
   }) async {
     try {
-      print('📍 주변 게시글 조회: lat=$latitude, lng=$longitude, radius=$radius, sortBy=$sortBy, categories=$categories');
+      print(
+        '📍 주변 게시글 조회: lat=$latitude, lng=$longitude, radius=$radius, sortBy=$sortBy, categories=$categories',
+      );
 
       // 쿼리 파라미터 생성
       final queryParameters = <String, dynamic>{
@@ -303,9 +371,7 @@ class PostService {
           return response.data as List<dynamic>;
         }
       } else {
-        throw Exception(
-          '주변 게시글 조회에 실패했습니다. (Status: ${response.statusCode})',
-        );
+        throw Exception('주변 게시글 조회에 실패했습니다. (Status: ${response.statusCode})');
       }
     } on DioException catch (e) {
       print('❌ DioException 발생:');

--- a/lib/data/services/post_service.dart
+++ b/lib/data/services/post_service.dart
@@ -137,7 +137,7 @@ class PostService {
         throw Exception('게시글 작성에 실패했습니다. (Status: ${response.statusCode})');
       }
     } on DioException catch (e) {
-      print('❌ DioException 발생:');
+      print('❌ DioException 발생 (createContestPost):');
       print('Status Code: ${e.response?.statusCode}');
       print('Response Data: ${e.response?.data}');
       print('Error Message: ${e.message}');
@@ -150,6 +150,10 @@ class PostService {
         throw Exception('인증이 필요합니다. 로그인 후 다시 시도해주세요.');
       } else if (e.response?.statusCode == 403) {
         throw Exception('권한이 없습니다.');
+      } else if (e.response?.statusCode == 409) {
+        final errorMsg = e.response?.data?.toString() ?? '이미 참여한 챌린지입니다.';
+        print('⚠️ 409 에러 상세: $errorMsg');
+        throw Exception('중복 참여: $errorMsg');
       } else if (e.response?.statusCode == 500) {
         final errorMsg = e.response?.data?.toString() ?? '서버 오류가 발생했습니다.';
         throw Exception('서버 오류: $errorMsg');

--- a/lib/data/services/suggestion_service.dart
+++ b/lib/data/services/suggestion_service.dart
@@ -1,0 +1,73 @@
+import 'package:dio/dio.dart';
+import 'api_service.dart';
+
+/// 제안 게시물 관련 API 서비스
+class SuggestionService {
+  final ApiService _apiService = ApiService();
+
+  /// 특정 공모전의 제출물 목록 조회
+  ///
+  /// [contestId]: 공모전 ID
+  /// [sortBy]: 정렬 기준 (createdAt 또는 empathy, 기본값: createdAt)
+  /// [page]: 페이지 번호 (기본값: 0)
+  /// [size]: 페이지 크기 (기본값: 20)
+  ///
+  /// 요약 정보만 반환 (title, userId, imagePath, empathy, createdAt)
+  Future<List<dynamic>> getContestPosts({
+    required int contestId,
+    String? sortBy,
+    int page = 0,
+    int size = 20,
+  }) async {
+    try {
+      // 쿼리 파라미터 구성
+      final queryParams = <String, dynamic>{
+        'page': page,
+        'size': size,
+      };
+
+      if (sortBy != null) {
+        queryParams['sortBy'] = sortBy;
+      }
+
+      final response = await _apiService.get(
+        '/v0/contests/$contestId/posts',
+        queryParameters: queryParams,
+      );
+
+      if (response.statusCode == 200) {
+        print('📦 API 응답 데이터 타입: ${response.data.runtimeType}');
+        print('📦 API 응답 데이터: ${response.data}');
+
+        // 응답이 Map인 경우 (페이징된 데이터)
+        if (response.data is Map<String, dynamic>) {
+          final data = response.data as Map<String, dynamic>;
+          // content 배열 추출 (Spring Boot 페이징 응답 구조)
+          if (data.containsKey('content')) {
+            return data['content'] as List<dynamic>;
+          }
+          // data 배열 추출
+          if (data.containsKey('data')) {
+            return data['data'] as List<dynamic>;
+          }
+          throw Exception('예상치 못한 응답 구조입니다.');
+        }
+
+        // 응답이 List인 경우
+        return response.data as List<dynamic>;
+      } else {
+        throw Exception('제출물 목록 조회에 실패했습니다. (Status: ${response.statusCode})');
+      }
+    } on DioException catch (e) {
+      print('❌ DioException 발생:');
+      print('Status Code: ${e.response?.statusCode}');
+      print('Response Data: ${e.response?.data}');
+      print('Error Message: ${e.message}');
+      print('Request Data: ${e.requestOptions.data}');
+      throw Exception('제출물 목록 조회 중 오류가 발생했습니다.');
+    } catch (e) {
+      print('❌ Unexpected Error: $e');
+      rethrow;
+    }
+  }
+}

--- a/lib/data/services/user_service.dart
+++ b/lib/data/services/user_service.dart
@@ -59,7 +59,7 @@ class UserService {
 
       // 프로덕션 모드: 실제 API 호출
       // Spring Boot 엔드포인트: GET /api/user/{userId}
-      final response = await _apiService.get('/user/$userId');
+      final response = await _apiService.get('/users/$userId');
 
       if (response.statusCode == 200) {
         return response.data as Map<String, dynamic>;

--- a/lib/screens/challenges/challenge_all_screen.dart
+++ b/lib/screens/challenges/challenge_all_screen.dart
@@ -169,6 +169,7 @@ class _ChallengeAllScreen extends State<ChallengeAllScreen> {
                           categoryType: categoryType ?? CategoryType.NATURE,
                           title: challenge['title']?.toString() ?? '제목 없음',
                           location: hostText,
+                          contestId: challenge['contestId'] ?? 0,
                         ),
                       );
                     })
@@ -223,6 +224,7 @@ class _ChallengeAllScreen extends State<ChallengeAllScreen> {
                           categoryType: categoryType ?? CategoryType.NATURE,
                           title: challenge['title']?.toString() ?? '제목 없음',
                           location: hostText,
+                          contestId: challenge['contestId'] ?? 0,
                         ),
                       );
                     })

--- a/lib/screens/challenges/challenge_detail_screen.dart
+++ b/lib/screens/challenges/challenge_detail_screen.dart
@@ -2,18 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:miyo/components/title_appbar.dart';
 import 'package:miyo/screens/challenges/challenge_item.dart';
 import 'package:miyo/screens/imaginary_map/suggestion_top3.dart';
-import 'package:miyo/screens/imaginary_map/suggestion_item.dart' as suggestion_lib;
+import 'package:miyo/screens/imaginary_map/suggestion_item.dart'
+    as suggestion_lib;
 import 'package:miyo/screens/suggestion/suggestion_detail_screen.dart';
 import 'package:miyo/screens/suggestion/suggestion_screen.dart';
 import 'package:miyo/data/services/challenge_service.dart';
+import 'package:miyo/screens/suggestion/suggestion_all_screen.dart';
 
 class ChallengeDetailScreen extends StatefulWidget {
   final int contestId;
 
-  const ChallengeDetailScreen({
-    super.key,
-    required this.contestId,
-  });
+  const ChallengeDetailScreen({super.key, required this.contestId});
 
   @override
   State<ChallengeDetailScreen> createState() => _ChallengeDetailScreenState();
@@ -36,8 +35,9 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
     });
 
     try {
-      final data =
-          await _challengeService.getContestById(contestId: widget.contestId);
+      final data = await _challengeService.getContestById(
+        contestId: widget.contestId,
+      );
       print('📦 챌린지 데이터: $data');
       setState(() {
         contestData = data;
@@ -94,9 +94,7 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
         backgroundColor: Colors.white,
         appBar: TitleAppbar(title: '챌린지 정보', leadingType: LeadingType.close),
         body: Center(
-          child: CircularProgressIndicator(
-            color: Color(0xff00AA5D),
-          ),
+          child: CircularProgressIndicator(color: Color(0xff00AA5D)),
         ),
       );
     }
@@ -310,6 +308,14 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
                   TextButton(
                     onPressed: () {
                       // 챌린지 제안 리스트 페이지로 이동
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => SuggestionAllScreen(
+                            contestId: widget.contestId,
+                          ),
+                        ),
+                      );
                     },
                     child: Text(
                       '+ 더보기',
@@ -328,10 +334,7 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
                   padding: const EdgeInsets.symmetric(vertical: 20),
                   child: Text(
                     '아직 제안이 없습니다.',
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: Colors.grey,
-                    ),
+                    style: TextStyle(fontSize: 14, color: Colors.grey),
                   ),
                 )
               else
@@ -347,7 +350,9 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
                     itemBuilder: (context, index) {
                       final post = topPosts[index];
                       return SuggestionTop3(
-                        categoryType: _getSuggestionCategoryType(post['category']),
+                        categoryType: _getSuggestionCategoryType(
+                          post['category'],
+                        ),
                         title: post['title'] ?? '제목 없음',
                         writer: post['userId'] ?? '익명',
                         rank: index + 1,

--- a/lib/screens/challenges/challenge_detail_screen.dart
+++ b/lib/screens/challenges/challenge_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:miyo/screens/challenges/challenge_item.dart';
 import 'package:miyo/screens/imaginary_map/suggestion_top3.dart';
 import 'package:miyo/screens/imaginary_map/suggestion_item.dart' as suggestion_lib;
 import 'package:miyo/screens/suggestion/suggestion_detail_screen.dart';
+import 'package:miyo/screens/suggestion/suggestion_screen.dart';
 import 'package:miyo/data/services/challenge_service.dart';
 
 class ChallengeDetailScreen extends StatefulWidget {
@@ -132,48 +133,22 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
           color: Colors.white,
           child: ElevatedButton(
             style: ElevatedButton.styleFrom(
-              backgroundColor: contestData!['isParticipant'] == true
-                  ? Colors.grey
-                  : const Color(0xFF00AA5D),
+              backgroundColor: const Color(0xFF00AA5D),
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
               minimumSize: const Size.fromHeight(50),
             ),
-            onPressed: contestData!['isParticipant'] == true
-                ? null
-                : () async {
-                    // 참여하기 버튼 동작
-                    try {
-                      await _challengeService.joinContest(
-                        contestId: widget.contestId,
-                      );
-
-                      // 참여 성공 후 데이터 다시 로드
-                      await _loadContestData();
-
-                      if (mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(
-                            content: Text('챌린지 참가가 완료되었습니다!'),
-                            backgroundColor: Color(0xff00AA5D),
-                          ),
-                        );
-                      }
-                    } catch (e) {
-                      print('❌ 챌린지 참가 실패: $e');
-                      if (mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(e.toString().replaceAll('Exception: ', '')),
-                            backgroundColor: Colors.red,
-                          ),
-                        );
-                      }
-                    }
-                  },
-            child: Text(
-              contestData!['isParticipant'] == true ? '참여중' : '참여하기',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const SuggestionScreen(),
+                ),
+              );
+            },
+            child: const Text(
+              '참여하기',
               style: TextStyle(
                 color: Colors.white,
                 fontSize: 16,

--- a/lib/screens/challenges/challenge_detail_screen.dart
+++ b/lib/screens/challenges/challenge_detail_screen.dart
@@ -141,7 +141,7 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => const SuggestionScreen(),
+                  builder: (context) => const SuggestionScreen(isContent: true),
                 ),
               );
             },
@@ -311,9 +311,8 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (context) => SuggestionAllScreen(
-                            contestId: widget.contestId,
-                          ),
+                          builder: (context) =>
+                              SuggestionAllScreen(contestId: widget.contestId),
                         ),
                       );
                     },

--- a/lib/screens/challenges/challenge_detail_screen.dart
+++ b/lib/screens/challenges/challenge_detail_screen.dart
@@ -3,22 +3,106 @@ import 'package:miyo/components/title_appbar.dart';
 import 'package:miyo/components/challenge_item.dart';
 import 'package:miyo/screens/imaginary_map/suggestion_top3.dart';
 import 'package:miyo/screens/imaginary_map/suggestion_item.dart';
-import 'package:miyo/data/dummy/dummy_suggestions.dart';
 import 'package:miyo/screens/suggestion/suggestion_detail_screen.dart';
+import 'package:miyo/data/services/challenge_service.dart';
 
 class ChallengeDetailScreen extends StatefulWidget {
-  const ChallengeDetailScreen({super.key});
+  final int contestId;
+
+  const ChallengeDetailScreen({
+    super.key,
+    required this.contestId,
+  });
 
   @override
-  State<ChallengeDetailScreen> createState() => _ChallengeDetailScreen();
+  State<ChallengeDetailScreen> createState() => _ChallengeDetailScreenState();
 }
 
-class _ChallengeDetailScreen extends State<ChallengeDetailScreen> {
-  // 챌린지 정보(챌린지 제목, 주관, 기간, 설명, 보상)내용 받아오기 필요
+class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
+  final ChallengeService _challengeService = ChallengeService();
+  Map<String, dynamic>? contestData;
+  bool isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadContestData();
+  }
+
+  Future<void> _loadContestData() async {
+    setState(() {
+      isLoading = true;
+    });
+
+    try {
+      final data =
+          await _challengeService.getContestById(contestId: widget.contestId);
+      print('📦 챌린지 데이터: $data');
+      setState(() {
+        contestData = data;
+        isLoading = false;
+      });
+    } catch (e) {
+      print('❌ 챌린지 로드 실패: $e');
+      if (mounted) {
+        setState(() {
+          isLoading = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('챌린지를 불러오는데 실패했습니다.'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  String getCategoryIcon(String? category) {
+    // 카테고리에 따라 아이콘 반환 (필요시 수정)
+    return category ?? 'NATURE';
+  }
 
   @override
   Widget build(BuildContext context) {
-    final top3Suggestions = getTop3Suggestions();
+    final width = MediaQuery.of(context).size.width;
+
+    // 로딩 중
+    if (isLoading) {
+      return Scaffold(
+        backgroundColor: Colors.white,
+        appBar: TitleAppbar(title: '챌린지 정보', leadingType: LeadingType.close),
+        body: Center(
+          child: CircularProgressIndicator(
+            color: Color(0xff00AA5D),
+          ),
+        ),
+      );
+    }
+
+    // 데이터 로드 실패
+    if (contestData == null) {
+      return Scaffold(
+        backgroundColor: Colors.white,
+        appBar: TitleAppbar(title: '챌린지 정보', leadingType: LeadingType.close),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.error_outline, size: 64, color: Colors.grey),
+              SizedBox(height: 16),
+              Text(
+                '챌린지를 불러올 수 없습니다.',
+                style: TextStyle(fontSize: 16, color: Colors.grey[700]),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final topPosts = (contestData!['topPosts'] as List<dynamic>?) ?? [];
+
     return Scaffold(
       appBar: TitleAppbar(title: '챌린지 정보', leadingType: LeadingType.close),
       backgroundColor: Colors.white,
@@ -28,17 +112,22 @@ class _ChallengeDetailScreen extends State<ChallengeDetailScreen> {
           color: Colors.white,
           child: ElevatedButton(
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFF00AA5D),
+              backgroundColor: contestData!['isParticipant'] == true
+                  ? Colors.grey
+                  : const Color(0xFF00AA5D),
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
               minimumSize: const Size.fromHeight(50),
             ),
-            onPressed: () {
-              // 참여하기 버튼 동작
-            },
-            child: const Text(
-              '참여하기',
+            onPressed: contestData!['isParticipant'] == true
+                ? null
+                : () {
+                    // 참여하기 버튼 동작
+                    print('챌린지 참여하기');
+                  },
+            child: Text(
+              contestData!['isParticipant'] == true ? '참여중' : '참여하기',
               style: TextStyle(
                 color: Colors.white,
                 fontSize: 16,
@@ -53,14 +142,15 @@ class _ChallengeDetailScreen extends State<ChallengeDetailScreen> {
           padding: const EdgeInsets.all(16.0),
           child: Column(
             children: [
-              const ChallengeItem(
+              ChallengeItem(
                 icon: Icons.apartment_rounded,
-                title: '2026 우리 동네 공원 상상하기',
-                location: '서울시',
+                title: contestData!['title'] ?? '제목 없음',
+                location: contestData!['host'] ?? '주최자 미상',
                 isTitleBox: true,
+                contestId: widget.contestId,
               ),
               SizedBox(
-                width: MediaQuery.of(context).size.width,
+                width: width,
                 child: Divider(color: Color(0x3E000000), thickness: 1.0),
               ),
               SizedBox(height: 17),
@@ -85,7 +175,7 @@ class _ChallengeDetailScreen extends State<ChallengeDetailScreen> {
                           ),
                         ),
                         Text(
-                          '2025-09-24 ~ 2026-08-19',
+                          '${contestData!['startDate'] ?? ''} ~ ${contestData!['endDate'] ?? ''}',
                           style: TextStyle(
                             fontSize: 14,
                             fontWeight: FontWeight.normal,
@@ -100,7 +190,37 @@ class _ChallengeDetailScreen extends State<ChallengeDetailScreen> {
                           ),
                         ),
                         Text(
-                          '성북구 정릉로 77로에 새로 생길 공원에 대한 의견을 모집합니다.',
+                          contestData!['description'] ?? '설명이 없습니다.',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.normal,
+                          ),
+                        ),
+                        SizedBox(height: 7),
+                        const Text(
+                          '참여자 수',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text(
+                          '${contestData!['participantCount'] ?? 0}명',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.normal,
+                          ),
+                        ),
+                        SizedBox(height: 7),
+                        const Text(
+                          '제출된 글',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text(
+                          '${contestData!['submissionCount'] ?? 0}개',
                           style: TextStyle(
                             fontSize: 14,
                             fontWeight: FontWeight.normal,
@@ -118,39 +238,45 @@ class _ChallengeDetailScreen extends State<ChallengeDetailScreen> {
                   Padding(
                     padding: const EdgeInsets.all(4.0),
                     child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          '1등 : 1000포인트',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.normal,
+                        if (contestData!['reward1st'] != null)
+                          Text(
+                            '1등 : ${contestData!['reward1st']}',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.normal,
+                            ),
                           ),
-                        ),
-                        Text(
-                          '2등 : 700포인트',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.normal,
+                        if (contestData!['reward2nd'] != null)
+                          Text(
+                            '2등 : ${contestData!['reward2nd']}',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.normal,
+                            ),
                           ),
-                        ),
-                        Text(
-                          '3등 : 500포인트',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.normal,
+                        if (contestData!['reward3rd'] != null)
+                          Text(
+                            '3등 : ${contestData!['reward3rd']}',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.normal,
+                            ),
                           ),
-                        ),
                       ],
                     ),
                   ),
-                  SizedBox(height: 14),
-                  Text(
-                    '*모든 수상작은 공원 설계 및 시공에 반영될 수 있습니다.*',
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.normal,
+                  if (contestData!['rewardDescription'] != null) ...[
+                    SizedBox(height: 14),
+                    Text(
+                      '*${contestData!['rewardDescription']}*',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.normal,
+                      ),
                     ),
-                  ),
+                  ],
                 ],
               ),
               SizedBox(height: 50),
@@ -162,7 +288,9 @@ class _ChallengeDetailScreen extends State<ChallengeDetailScreen> {
                     style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                   ),
                   TextButton(
-                    onPressed: () {}, // 챌린지 제안 리스트 페이지로 이동
+                    onPressed: () {
+                      // 챌린지 제안 리스트 페이지로 이동
+                    },
                     child: Text(
                       '+ 더보기',
                       style: TextStyle(
@@ -175,50 +303,74 @@ class _ChallengeDetailScreen extends State<ChallengeDetailScreen> {
                 ],
               ),
               SizedBox(height: 17),
-
-              SizedBox(
-                height: 100,
-                child: ListView.separated(
-                  scrollDirection: Axis.horizontal,
-                  clipBehavior: Clip.none,
-                  padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
-                  itemCount: top3Suggestions.length,
-                  separatorBuilder: (context, index) =>
-                      const SizedBox(width: 12),
-                  itemBuilder: (context, index) {
-                    final suggestion = top3Suggestions[index];
-                    return SuggestionTop3(
-                      categoryType: suggestion['categoryType'] as CategoryType,
-                      title: suggestion['title'] as String,
-                      writer: suggestion['writer'] as String,
-                      rank: index + 1,
-                      onTap: () {
-                        // TODO: 제안 상세 화면으로 이동
-                        // Navigator.push(
-                        //   context,
-                        //   MaterialPageRoute(
-                        //     builder: (context) => SuggestionDetailScreen(
-                        //       suggestionId: suggestion['id'] as int,
-                        //     ),
-                        //   ),
-                        // );
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => SuggestionDetailScreen(
-                              postId: suggestion['id'] as int,
+              if (topPosts.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 20),
+                  child: Text(
+                    '아직 제안이 없습니다.',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Colors.grey,
+                    ),
+                  ),
+                )
+              else
+                SizedBox(
+                  height: 100,
+                  child: ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    clipBehavior: Clip.none,
+                    padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
+                    itemCount: topPosts.length > 3 ? 3 : topPosts.length,
+                    separatorBuilder: (context, index) =>
+                        const SizedBox(width: 12),
+                    itemBuilder: (context, index) {
+                      final post = topPosts[index];
+                      return SuggestionTop3(
+                        categoryType: _getCategoryType(post['category']),
+                        title: post['title'] ?? '제목 없음',
+                        writer: post['userId'] ?? '익명',
+                        rank: index + 1,
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => SuggestionDetailScreen(
+                                postId: post['id'] ?? post['postId'] ?? 0,
+                              ),
                             ),
-                          ),
-                        );
-                      },
-                    );
-                  },
+                          );
+                        },
+                      );
+                    },
+                  ),
                 ),
-              ),
             ],
           ),
         ),
       ),
     );
+  }
+
+  CategoryType _getCategoryType(String? category) {
+    switch (category?.toUpperCase()) {
+      case 'NATURE':
+        return CategoryType.NATURE;
+      case 'CULTURE':
+        return CategoryType.CULTURE;
+      case 'TRAFFIC':
+        return CategoryType.TRAFFIC;
+      case 'RESIDENCE':
+        return CategoryType.RESIDENCE;
+      case 'COMMERCE':
+      case 'COMMERCIAL':
+        return CategoryType.COMMERCIAL;
+      case 'NIGHT':
+        return CategoryType.NIGHT;
+      case 'ENVIRONMENT':
+        return CategoryType.ENVIRONMENT;
+      default:
+        return CategoryType.NATURE;
+    }
   }
 }

--- a/lib/screens/challenges/challenge_detail_screen.dart
+++ b/lib/screens/challenges/challenge_detail_screen.dart
@@ -137,13 +137,28 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
               ),
               minimumSize: const Size.fromHeight(50),
             ),
-            onPressed: () {
-              Navigator.push(
+            onPressed: () async {
+              // 챌린지 참여 화면으로 이동
+              final latitude = contestData?['latitude'] as double?;
+              final longitude = contestData?['longitude'] as double?;
+
+              final result = await Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => const SuggestionScreen(isContent: true),
+                  builder: (context) => SuggestionScreen(
+                    isContest: true,
+                    contestId: widget.contestId,
+                    latitude: latitude,
+                    longitude: longitude,
+                  ),
                 ),
               );
+
+              // 게시글 작성 완료 후 돌아왔을 때 데이터 새로고침
+              if (result != null) {
+                print('✅ 게시글 작성 완료, 챌린지 데이터 새로고침');
+                _loadContestData();
+              }
             },
             child: const Text(
               '참여하기',

--- a/lib/screens/challenges/challenge_ing_screen.dart
+++ b/lib/screens/challenges/challenge_ing_screen.dart
@@ -82,6 +82,7 @@ class _ChallengeIngScreen extends State<ChallengeIngScreen> {
                       categoryType: _parseCategoryType(challenge['category']),
                       title: challenge['title'] ?? '',
                       location: challenge['host'] ?? '',
+                      contestId: challenge['contestId'] ?? 0,
                     );
                   },
                 ),

--- a/lib/screens/challenges/challenge_item.dart
+++ b/lib/screens/challenges/challenge_item.dart
@@ -6,12 +6,14 @@ class ChallengeItem extends StatelessWidget {
   final CategoryType? categoryType;
   final String title;
   final String location;
+  final int contestId;
 
   const ChallengeItem({
     super.key,
     required this.categoryType,
     required this.title,
     required this.location,
+    required this.contestId,
   });
 
   @override
@@ -55,7 +57,9 @@ class ChallengeItem extends StatelessWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => const ChallengeDetailScreen(),
+                  builder: (context) => ChallengeDetailScreen(
+                    contestId: contestId,
+                  ),
                 ),
               );
             },

--- a/lib/screens/challenges/challenge_screen.dart
+++ b/lib/screens/challenges/challenge_screen.dart
@@ -180,6 +180,7 @@ class _ChallengeScreenState extends State<ChallengeScreen> {
                             ),
                             title: challenge['title'] ?? '',
                             location: challenge['host'] ?? '',
+                            contestId: challenge['contestId'] ?? 0,
                           ),
                         );
                       }).toList(),
@@ -226,6 +227,7 @@ class _ChallengeScreenState extends State<ChallengeScreen> {
                             ),
                             title: challenge['title'] ?? '',
                             location: challenge['host'] ?? '',
+                            contestId: challenge['contestId'] ?? 0,
                           ),
                         );
                       }).toList(),

--- a/lib/screens/imaginary_map/imaginary_map_bottom_sheet.dart
+++ b/lib/screens/imaginary_map/imaginary_map_bottom_sheet.dart
@@ -159,8 +159,6 @@ class _ImaginaryMapBottomSheetState extends State<ImaginaryMapBottomSheet> {
         return 'empathy'; // 공감순
       case FilterType.latest:
         return 'latest'; // 최신순
-      case FilterType.distance:
-        return 'distance'; // 거리순
     }
   }
 

--- a/lib/screens/imaginary_map/suggestion_filtering_button.dart
+++ b/lib/screens/imaginary_map/suggestion_filtering_button.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 enum FilterType {
   popularity, // 인기순
   latest, // 최신순
-  distance, // 거리순
 }
 
 class SuggestionFilteringButton extends StatelessWidget {
@@ -19,7 +18,6 @@ class SuggestionFilteringButton extends StatelessWidget {
   static const Map<FilterType, String> filterNames = {
     FilterType.popularity: '인기순',
     FilterType.latest: '최신순',
-    FilterType.distance: '거리순',
   };
 
   @override
@@ -32,7 +30,6 @@ class SuggestionFilteringButton extends StatelessWidget {
       itemBuilder: (context) => [
         _buildMenuItem(FilterType.popularity),
         _buildMenuItem(FilterType.latest),
-        _buildMenuItem(FilterType.distance),
       ],
       child: Container(
         // 필터링 버튼

--- a/lib/screens/imaginary_map/suggestion_item.dart
+++ b/lib/screens/imaginary_map/suggestion_item.dart
@@ -56,9 +56,7 @@ class SuggestionItem extends StatelessWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => SuggestionDetailScreen(
-                    postId: postId,
-                  ),
+                  builder: (context) => SuggestionDetailScreen(postId: postId),
                 ),
               );
             },
@@ -131,5 +129,5 @@ enum CategoryType {
   RESIDENCE, // 주거/생활
   COMMERCIAL, // 상권/시장
   NIGHT, // 야간/경관
-  ENVIRONMENT // 환경/지속가능
+  ENVIRONMENT, // 환경/지속가능
 }

--- a/lib/screens/suggestion/suggestion_all_screen.dart
+++ b/lib/screens/suggestion/suggestion_all_screen.dart
@@ -157,13 +157,13 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                           title: suggestion['title']?.toString() ?? '제목 없음',
                           writer:
                               suggestion['userId']?.toString() ?? '작성자 정보 없음',
-                          postId: suggestion['postId'] as int,
+                          postId: suggestion['postId'] ?? 0,
                         ),
                       );
                     })
                   else
                     const Padding(
-                      padding: EdgeInsets.all(60.0),
+                      padding: EdgeInsets.all(100.0),
                       child: Center(child: Text('인기 제안이 없습니다')),
                     ),
 
@@ -199,7 +199,7 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                           title: suggestion['title']?.toString() ?? '제목 없음',
                           writer:
                               suggestion['userId']?.toString() ?? '작성자 정보 없음',
-                          postId: suggestion['postId'] as int,
+                          postId: suggestion['postId'] ?? 0,
                         ),
                       );
                     })

--- a/lib/screens/suggestion/suggestion_all_screen.dart
+++ b/lib/screens/suggestion/suggestion_all_screen.dart
@@ -157,7 +157,7 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                           title: suggestion['title']?.toString() ?? '제목 없음',
                           writer:
                               suggestion['userId']?.toString() ?? '작성자 정보 없음',
-                          postId: suggestion['postId'] ?? 0,
+                          postId: suggestion['postId'] as int,
                         ),
                       );
                     })
@@ -199,7 +199,7 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                           title: suggestion['title']?.toString() ?? '제목 없음',
                           writer:
                               suggestion['userId']?.toString() ?? '작성자 정보 없음',
-                          postId: suggestion['postId'] ?? 0,
+                          postId: suggestion['postId'] as int,
                         ),
                       );
                     })

--- a/lib/screens/suggestion/suggestion_all_screen.dart
+++ b/lib/screens/suggestion/suggestion_all_screen.dart
@@ -151,7 +151,9 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 20),
                         child: SuggestionItem(
-                          categoryType: _parseCategoryType(suggestion['category']),
+                          categoryType: _parseCategoryType(
+                            suggestion['category'],
+                          ),
                           title: suggestion['title']?.toString() ?? '제목 없음',
                           writer:
                               suggestion['userId']?.toString() ?? '작성자 정보 없음',
@@ -161,7 +163,7 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                     })
                   else
                     const Padding(
-                      padding: EdgeInsets.all(20.0),
+                      padding: EdgeInsets.all(60.0),
                       child: Center(child: Text('인기 제안이 없습니다')),
                     ),
 
@@ -191,7 +193,9 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 20),
                         child: SuggestionItem(
-                          categoryType: _parseCategoryType(suggestion['category']),
+                          categoryType: _parseCategoryType(
+                            suggestion['category'],
+                          ),
                           title: suggestion['title']?.toString() ?? '제목 없음',
                           writer:
                               suggestion['userId']?.toString() ?? '작성자 정보 없음',

--- a/lib/screens/suggestion/suggestion_all_screen.dart
+++ b/lib/screens/suggestion/suggestion_all_screen.dart
@@ -7,10 +7,7 @@ import 'package:miyo/data/services/suggestion_service.dart';
 class SuggestionAllScreen extends StatefulWidget {
   final int contestId;
 
-  const SuggestionAllScreen({
-    super.key,
-    required this.contestId,
-  });
+  const SuggestionAllScreen({super.key, required this.contestId});
 
   @override
   State<SuggestionAllScreen> createState() => _SuggestionAllScreenState();
@@ -90,103 +87,102 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : _errorMessage != null
-              ? Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    '제안 글을 불러오는데 실패했습니다',
+                    style: TextStyle(fontSize: 16, color: Colors.grey[600]),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    _errorMessage!,
+                    style: TextStyle(fontSize: 12, color: Colors.grey[400]),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: _loadSuggestions,
+                    child: const Text('다시 시도'),
+                  ),
+                ],
+              ),
+            )
+          : RefreshIndicator(
+              onRefresh: _loadSuggestions,
+              child: ListView(
+                padding: const EdgeInsets.all(16.0),
+                children: [
+                  // 인기 제안 TOP3 섹션
+                  const Text(
+                    '인기 제안 TOP3',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 16),
+
+                  // TOP3 제안 리스트
+                  if (_topSuggestions.isNotEmpty)
+                    ..._topSuggestions.map((suggestion) {
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 20),
+                        child: SuggestionItem(
+                          categoryType: null, // 필요시 카테고리 파싱 로직 추가
+                          title: suggestion['title']?.toString() ?? '제목 없음',
+                          writer:
+                              suggestion['userId']?.toString() ?? '작성자 정보 없음',
+                          postId: suggestion['postId'] ?? 0,
+                        ),
+                      );
+                    })
+                  else
+                    const Padding(
+                      padding: EdgeInsets.all(20.0),
+                      child: Center(child: Text('인기 제안이 없습니다')),
+                    ),
+
+                  const SizedBox(height: 8),
+
+                  // 필터 드롭다운
+                  Row(
                     children: [
-                      Text(
-                        '제안 글을 불러오는데 실패했습니다',
-                        style: TextStyle(fontSize: 16, color: Colors.grey[600]),
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        _errorMessage!,
-                        style: TextStyle(fontSize: 12, color: Colors.grey[400]),
-                        textAlign: TextAlign.center,
-                      ),
-                      const SizedBox(height: 16),
-                      ElevatedButton(
-                        onPressed: _loadSuggestions,
-                        child: const Text('다시 시도'),
+                      // 정렬 드롭다운
+                      SuggestionFilteringButton(
+                        selectedFilter: _sortBy,
+                        onFilterChanged: (filter) {
+                          setState(() {
+                            _sortBy = filter;
+                          });
+                          _loadSuggestions();
+                        },
                       ),
                     ],
                   ),
-                )
-              : RefreshIndicator(
-                  onRefresh: _loadSuggestions,
-                  child: ListView(
-                    padding: const EdgeInsets.all(16.0),
-                    children: [
-                      // 인기 제안 TOP3 섹션
-                      const Text(
-                        '인기 제안 TOP3',
-                        style: TextStyle(
-                            fontSize: 16, fontWeight: FontWeight.bold),
-                      ),
-                      const SizedBox(height: 16),
 
-                      // TOP3 제안 리스트
-                      if (_topSuggestions.isNotEmpty)
-                        ..._topSuggestions.map((suggestion) {
-                          return Padding(
-                            padding: const EdgeInsets.only(bottom: 20),
-                            child: SuggestionItem(
-                              categoryType: null, // 필요시 카테고리 파싱 로직 추가
-                              title: suggestion['title']?.toString() ?? '제목 없음',
-                              writer:
-                                  suggestion['userId']?.toString() ?? '작성자 정보 없음',
-                              postId: suggestion['postId'] ?? 0,
-                            ),
-                          );
-                        })
-                      else
-                        const Padding(
-                          padding: EdgeInsets.all(20.0),
-                          child: Center(child: Text('인기 제안이 없습니다')),
+                  const SizedBox(height: 16),
+
+                  // 전체 제안 리스트
+                  if (_allSuggestions.isNotEmpty)
+                    ..._allSuggestions.map((suggestion) {
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 20),
+                        child: SuggestionItem(
+                          categoryType: null, // 필요시 카테고리 파싱 로직 추가
+                          title: suggestion['title']?.toString() ?? '제목 없음',
+                          writer:
+                              suggestion['userId']?.toString() ?? '작성자 정보 없음',
+                          postId: suggestion['postId'] ?? 0,
                         ),
-
-                      const SizedBox(height: 8),
-
-                      // 필터 드롭다운
-                      Row(
-                        children: [
-                          // 정렬 드롭다운
-                          SuggestionFilteringButton(
-                            selectedFilter: _sortBy,
-                            onFilterChanged: (filter) {
-                              setState(() {
-                                _sortBy = filter;
-                              });
-                              _loadSuggestions();
-                            },
-                          ),
-                        ],
-                      ),
-
-                      const SizedBox(height: 16),
-
-                      // 전체 제안 리스트
-                      if (_allSuggestions.isNotEmpty)
-                        ..._allSuggestions.map((suggestion) {
-                          return Padding(
-                            padding: const EdgeInsets.only(bottom: 20),
-                            child: SuggestionItem(
-                              categoryType: null, // 필요시 카테고리 파싱 로직 추가
-                              title: suggestion['title']?.toString() ?? '제목 없음',
-                              writer:
-                                  suggestion['userId']?.toString() ?? '작성자 정보 없음',
-                              postId: suggestion['postId'] ?? 0,
-                            ),
-                          );
-                        })
-                      else
-                        const Padding(
-                          padding: EdgeInsets.all(20.0),
-                          child: Center(child: Text('제안이 없습니다')),
-                        ),
-                    ],
-                  ),
-                ),
+                      );
+                    })
+                  else
+                    const Padding(
+                      padding: EdgeInsets.all(20.0),
+                      child: Center(child: Text('제안이 없습니다')),
+                    ),
+                ],
+              ),
+            ),
     );
   }
 }

--- a/lib/screens/suggestion/suggestion_all_screen.dart
+++ b/lib/screens/suggestion/suggestion_all_screen.dart
@@ -79,6 +79,30 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
     return sortedList.take(3).toList();
   }
 
+  /// 카테고리 문자열을 CategoryType enum으로 변환
+  CategoryType? _parseCategoryType(String? category) {
+    if (category == null) return null;
+
+    switch (category.toUpperCase()) {
+      case 'NATURE':
+        return CategoryType.NATURE;
+      case 'CULTURE':
+        return CategoryType.CULTURE;
+      case 'TRAFFIC':
+        return CategoryType.TRAFFIC;
+      case 'RESIDENCE':
+        return CategoryType.RESIDENCE;
+      case 'COMMERCIAL':
+        return CategoryType.COMMERCIAL;
+      case 'NIGHT':
+        return CategoryType.NIGHT;
+      case 'ENVIRONMENT':
+        return CategoryType.ENVIRONMENT;
+      default:
+        return null;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -127,7 +151,7 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 20),
                         child: SuggestionItem(
-                          categoryType: null, // 필요시 카테고리 파싱 로직 추가
+                          categoryType: _parseCategoryType(suggestion['category']),
                           title: suggestion['title']?.toString() ?? '제목 없음',
                           writer:
                               suggestion['userId']?.toString() ?? '작성자 정보 없음',
@@ -167,7 +191,7 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 20),
                         child: SuggestionItem(
-                          categoryType: null, // 필요시 카테고리 파싱 로직 추가
+                          categoryType: _parseCategoryType(suggestion['category']),
                           title: suggestion['title']?.toString() ?? '제목 없음',
                           writer:
                               suggestion['userId']?.toString() ?? '작성자 정보 없음',

--- a/lib/screens/suggestion/suggestion_all_screen.dart
+++ b/lib/screens/suggestion/suggestion_all_screen.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import 'package:miyo/components/title_appbar.dart';
+import 'package:miyo/screens/imaginary_map/suggestion_item.dart';
+import 'package:miyo/screens/imaginary_map/suggestion_filtering_button.dart';
+import 'package:miyo/data/services/suggestion_service.dart';
+
+class SuggestionAllScreen extends StatefulWidget {
+  final int contestId;
+
+  const SuggestionAllScreen({
+    super.key,
+    required this.contestId,
+  });
+
+  @override
+  State<SuggestionAllScreen> createState() => _SuggestionAllScreenState();
+}
+
+class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
+  final SuggestionService _suggestionService = SuggestionService();
+  FilterType _sortBy = FilterType.latest;
+
+  List<dynamic> _allSuggestions = [];
+  bool _isLoading = true;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSuggestions();
+  }
+
+  Future<void> _loadSuggestions() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      // 정렬 기준 변환
+      String? sortByValue;
+      if (_sortBy == FilterType.popularity) {
+        sortByValue = 'empathy'; // 인기순 (공감순)
+      } else if (_sortBy == FilterType.latest) {
+        sortByValue = 'createdAt'; // 최신순
+      }
+      // distance는 현재 API에서 지원하지 않으므로 null로 처리
+
+      final suggestions = await _suggestionService.getContestPosts(
+        contestId: widget.contestId,
+        sortBy: sortByValue,
+        page: 0,
+        size: 20,
+      );
+
+      // 디버깅: 첫 번째 제안 글 데이터 구조 출력
+      if (suggestions.isNotEmpty) {
+        print('📦 첫 번째 제안글 데이터: ${suggestions[0]}');
+        print('📦 사용 가능한 키들: ${(suggestions[0] as Map).keys.toList()}');
+      }
+
+      setState(() {
+        _allSuggestions = suggestions;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  List<dynamic> get _topSuggestions {
+    // 인기 TOP3는 공감(empathy) 기준으로 정렬
+    var sortedList = _allSuggestions.toList();
+    sortedList.sort((a, b) {
+      final empathyA = a['empathy'] ?? 0;
+      final empathyB = b['empathy'] ?? 0;
+      return (empathyB as int).compareTo(empathyA as int);
+    });
+    return sortedList.take(3).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: TitleAppbar(title: '전체 제안 보기', leadingType: LeadingType.back),
+      backgroundColor: Colors.white,
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _errorMessage != null
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        '제안 글을 불러오는데 실패했습니다',
+                        style: TextStyle(fontSize: 16, color: Colors.grey[600]),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        _errorMessage!,
+                        style: TextStyle(fontSize: 12, color: Colors.grey[400]),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: _loadSuggestions,
+                        child: const Text('다시 시도'),
+                      ),
+                    ],
+                  ),
+                )
+              : RefreshIndicator(
+                  onRefresh: _loadSuggestions,
+                  child: ListView(
+                    padding: const EdgeInsets.all(16.0),
+                    children: [
+                      // 인기 제안 TOP3 섹션
+                      const Text(
+                        '인기 제안 TOP3',
+                        style: TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.bold),
+                      ),
+                      const SizedBox(height: 16),
+
+                      // TOP3 제안 리스트
+                      if (_topSuggestions.isNotEmpty)
+                        ..._topSuggestions.map((suggestion) {
+                          return Padding(
+                            padding: const EdgeInsets.only(bottom: 20),
+                            child: SuggestionItem(
+                              categoryType: null, // 필요시 카테고리 파싱 로직 추가
+                              title: suggestion['title']?.toString() ?? '제목 없음',
+                              writer:
+                                  suggestion['userId']?.toString() ?? '작성자 정보 없음',
+                              postId: suggestion['postId'] ?? 0,
+                            ),
+                          );
+                        })
+                      else
+                        const Padding(
+                          padding: EdgeInsets.all(20.0),
+                          child: Center(child: Text('인기 제안이 없습니다')),
+                        ),
+
+                      const SizedBox(height: 8),
+
+                      // 필터 드롭다운
+                      Row(
+                        children: [
+                          // 정렬 드롭다운
+                          SuggestionFilteringButton(
+                            selectedFilter: _sortBy,
+                            onFilterChanged: (filter) {
+                              setState(() {
+                                _sortBy = filter;
+                              });
+                              _loadSuggestions();
+                            },
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 16),
+
+                      // 전체 제안 리스트
+                      if (_allSuggestions.isNotEmpty)
+                        ..._allSuggestions.map((suggestion) {
+                          return Padding(
+                            padding: const EdgeInsets.only(bottom: 20),
+                            child: SuggestionItem(
+                              categoryType: null, // 필요시 카테고리 파싱 로직 추가
+                              title: suggestion['title']?.toString() ?? '제목 없음',
+                              writer:
+                                  suggestion['userId']?.toString() ?? '작성자 정보 없음',
+                              postId: suggestion['postId'] ?? 0,
+                            ),
+                          );
+                        })
+                      else
+                        const Padding(
+                          padding: EdgeInsets.all(20.0),
+                          child: Center(child: Text('제안이 없습니다')),
+                        ),
+                    ],
+                  ),
+                ),
+    );
+  }
+}

--- a/lib/screens/suggestion/suggestion_screen.dart
+++ b/lib/screens/suggestion/suggestion_screen.dart
@@ -185,8 +185,8 @@ class _SuggestionScreenState extends State<SuggestionScreen> {
       return;
     }
 
-    if ((widget.latitude == null && widget.isContest) ||
-        (widget.longitude == null && widget.isContest)) {
+    // 일반 게시글(isContest가 false)일 때만 위치 정보 필수
+    if (!widget.isContest && (widget.latitude == null || widget.longitude == null)) {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('위치 정보가 없습니다.')));

--- a/lib/screens/suggestion/suggestion_screen.dart
+++ b/lib/screens/suggestion/suggestion_screen.dart
@@ -10,8 +10,16 @@ import 'package:miyo/screens/suggestion/ai_suggestion_screen.dart';
 class SuggestionScreen extends StatefulWidget {
   final double? latitude;
   final double? longitude;
+  final bool isContest;
+  final int? contestId;
 
-  const SuggestionScreen({super.key, this.latitude, this.longitude});
+  const SuggestionScreen({
+    super.key,
+    this.latitude,
+    this.longitude,
+    this.isContest = false,
+    this.contestId,
+  });
 
   @override
   State<SuggestionScreen> createState() => _SuggestionScreenState();
@@ -142,7 +150,8 @@ class _SuggestionScreenState extends State<SuggestionScreen> {
       );
 
       // 업로드된 이미지 URL 반환 (응답 구조에 따라 수정 필요)
-      final imageUrl = response['imageUrl'] ?? response['url'] ?? response['imagePath'];
+      final imageUrl =
+          response['imageUrl'] ?? response['url'] ?? response['imagePath'];
 
       print('✅ 이미지 업로드 성공: $imageUrl');
       return imageUrl as String?;
@@ -176,7 +185,8 @@ class _SuggestionScreenState extends State<SuggestionScreen> {
       return;
     }
 
-    if (widget.latitude == null || widget.longitude == null) {
+    if ((widget.latitude == null && widget.isContest) ||
+        (widget.longitude == null && widget.isContest)) {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('위치 정보가 없습니다.')));
@@ -217,14 +227,28 @@ class _SuggestionScreenState extends State<SuggestionScreen> {
       print('- 이미지: $imagePath');
 
       // API 호출
-      final result = await _postService.createPost(
-        imagePath: imagePath,
-        latitude: widget.latitude!,
-        longitude: widget.longitude!,
-        category: categoryApiValues[selectedIndex!],
-        title: _titleController.text.trim(),
-        content: _contentController.text.trim(),
-      );
+      final result;
+      if (widget.isContest) {
+        if (widget.contestId == null) {
+          throw Exception('챌린지 ID가 필요합니다.');
+        }
+        result = await _postService.createContestPost(
+          contestId: widget.contestId!,
+          imagePath: imagePath,
+          category: categoryApiValues[selectedIndex!],
+          title: _titleController.text.trim(),
+          content: _contentController.text.trim(),
+        );
+      } else {
+        result = await _postService.createPost(
+          imagePath: imagePath,
+          latitude: widget.latitude!,
+          longitude: widget.longitude!,
+          category: categoryApiValues[selectedIndex!],
+          title: _titleController.text.trim(),
+          content: _contentController.text.trim(),
+        );
+      }
 
       print('✅ 게시글 등록 성공: $result');
 


### PR DESCRIPTION
## 📝작업 내용
( #50 ) 
- 챌린지 백엔드 연동
- 챌린지 내 제안 목록 페이지 생성
- 챌린지 내 제안 목록 페이지 백엔드 연동

### 스크린샷

## 💬리뷰 요구사항