### PR TITLE
[FEAT] 챌린지 내 제안글 & 기본 제안글 분리 및 디자인 일부 수정

### DIFF
--- a/lib/components/challenge_filtering_button.dart
+++ b/lib/components/challenge_filtering_button.dart
@@ -33,31 +33,34 @@ class ChallengeFilterButton extends StatelessWidget {
       ],
       child: Container(
         // 필터링 버튼
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
         decoration: BoxDecoration(
-          border: Border.all(color: const Color(0xffE0E0E0)),
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(20),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min, // Row 크기를 내용물에 맞춤
           children: [
+            Icon(Icons.filter_list, size: 18, color: Color(0xff61758A)),
+            const SizedBox(width: 4),
             Text(
               filterNames[selectedFilter] ?? '',
-              style: const TextStyle(
+              style: TextStyle(
                 fontSize: 14,
                 fontWeight: FontWeight.w500,
-                color: Color(0xff000000),
+                color: Color(0xff61758A),
               ),
             ),
             const SizedBox(width: 4),
-            const Icon(Icons.keyboard_arrow_down, size: 20, color: Color(0xff000000)),
+            Icon(Icons.arrow_drop_down, size: 18, color: Color(0xff61758A)),
           ],
         ),
       ),
     );
   }
 
-  PopupMenuItem<ChallengeFilterType> _buildMenuItem(ChallengeFilterType filterType) {
+  PopupMenuItem<ChallengeFilterType> _buildMenuItem(
+    ChallengeFilterType filterType,
+  ) {
     final isSelected = selectedFilter == filterType;
     return PopupMenuItem<ChallengeFilterType>(
       value: filterType,
@@ -69,10 +72,13 @@ class ChallengeFilterButton extends StatelessWidget {
             style: TextStyle(
               fontSize: 14,
               fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-              color: isSelected ? const Color(0xff00AA5D) : const Color(0xff000000),
+              color: isSelected
+                  ? const Color(0xff00AA5D)
+                  : const Color(0xff000000),
             ),
           ),
-          if (isSelected) const Icon(Icons.check, size: 18, color: Color(0xff00AA5D)),
+          if (isSelected)
+            const Icon(Icons.check, size: 18, color: Color(0xff00AA5D)),
         ],
       ),
     );
@@ -130,31 +136,34 @@ class ChallengeCategoryButton extends StatelessWidget {
       ],
       child: Container(
         // 필터링 버튼
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
         decoration: BoxDecoration(
-          border: Border.all(color: const Color(0xffE0E0E0)),
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(20),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min, // Row 크기를 내용물에 맞춤
           children: [
+            Icon(Icons.filter_list, size: 18, color: Color(0xff61758A)),
+            const SizedBox(width: 4),
             Text(
               categoryNames[selectedCategory] ?? '',
-              style: const TextStyle(
+              style: TextStyle(
                 fontSize: 14,
                 fontWeight: FontWeight.w500,
-                color: Color(0xff000000),
+                color: Color(0xff61758A),
               ),
             ),
             const SizedBox(width: 4),
-            const Icon(Icons.keyboard_arrow_down, size: 20, color: Color(0xff000000)),
+            Icon(Icons.arrow_drop_down, size: 18, color: Color(0xff61758A)),
           ],
         ),
       ),
     );
   }
 
-  PopupMenuItem<ChallengeCategoryType> _buildMenuItem(ChallengeCategoryType categoryType) {
+  PopupMenuItem<ChallengeCategoryType> _buildMenuItem(
+    ChallengeCategoryType categoryType,
+  ) {
     final isSelected = selectedCategory == categoryType;
     return PopupMenuItem<ChallengeCategoryType>(
       value: categoryType,
@@ -166,10 +175,13 @@ class ChallengeCategoryButton extends StatelessWidget {
             style: TextStyle(
               fontSize: 14,
               fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-              color: isSelected ? const Color(0xff00AA5D) : const Color(0xff000000),
+              color: isSelected
+                  ? const Color(0xff00AA5D)
+                  : const Color(0xff000000),
             ),
           ),
-          if (isSelected) const Icon(Icons.check, size: 18, color: Color(0xff00AA5D)),
+          if (isSelected)
+            const Icon(Icons.check, size: 18, color: Color(0xff00AA5D)),
         ],
       ),
     );

--- a/lib/data/services/post_service.dart
+++ b/lib/data/services/post_service.dart
@@ -565,4 +565,54 @@ class PostService {
       rethrow;
     }
   }
+
+  /// 챌린지 내 제안 글 상세 조회
+  ///
+  /// [postId]: 조회할 게시글 ID
+  Future<Map<String, dynamic>> getContestsPostById({
+    required int contestId,
+  }) async {
+    try {
+      // 프로덕션 모드: 실제 API 호출
+      // Spring Boot 엔드포인트: GET /v0/posts/id
+      final response = await _apiService.get(
+        '/v0/contests/$contestId',
+        queryParameters: {'contestId': contestId},
+      );
+
+      if (response.statusCode == 200) {
+        final data = response.data as Map<String, dynamic>;
+        print('✅ getPostById API 응답:');
+        print('  - postId: ${data['postId']}');
+        print('  - nickname: ${data['nickname']}');
+        print('  - title: ${data['title']}');
+        print('  - 전체 데이터: $data');
+        return data;
+      } else {
+        throw Exception('게시글 조회에 실패했습니다. (Status: ${response.statusCode})');
+      }
+    } on DioException catch (e) {
+      print('❌ DioException 발생:');
+      print('Status Code: ${e.response?.statusCode}');
+      print('Response Data: ${e.response?.data}');
+      print('Error Message: ${e.message}');
+
+      if (e.response?.statusCode == 404) {
+        throw Exception('게시글을 찾을 수 없습니다.');
+      } else if (e.response?.statusCode == 401) {
+        throw Exception('인증이 필요합니다. 로그인 후 다시 시도해주세요.');
+      } else if (e.response?.statusCode == 403) {
+        throw Exception('권한이 없습니다.');
+      } else if (e.response?.statusCode == 500) {
+        final errorMsg = e.response?.data?.toString() ?? '서버 오류가 발생했습니다.';
+        throw Exception('서버 오류: $errorMsg');
+      }
+      throw Exception(
+        '네트워크 오류: ${e.message} (Status: ${e.response?.statusCode})',
+      );
+    } catch (e) {
+      print('❌ Unexpected Error: $e');
+      rethrow;
+    }
+  }
 }

--- a/lib/data/services/post_service.dart
+++ b/lib/data/services/post_service.dart
@@ -571,13 +571,12 @@ class PostService {
   /// [postId]: 조회할 게시글 ID
   Future<Map<String, dynamic>> getContestsPostById({
     required int contestId,
+    required int postId,
   }) async {
     try {
-      // 프로덕션 모드: 실제 API 호출
-      // Spring Boot 엔드포인트: GET /v0/posts/id
       final response = await _apiService.get(
-        '/v0/contests/$contestId',
-        queryParameters: {'contestId': contestId},
+        '/v0/contests/$contestId/posts/$postId',
+        queryParameters: {'contestId': contestId, 'postId': postId},
       );
 
       if (response.statusCode == 200) {

--- a/lib/screens/challenges/challenge_all_screen.dart
+++ b/lib/screens/challenges/challenge_all_screen.dart
@@ -161,7 +161,8 @@ class _ChallengeAllScreen extends State<ChallengeAllScreen> {
                       final categoryType = _parseCategoryType(
                         challenge['category'],
                       );
-                      final hostText = challenge['host']?.toString() ?? '주최자 정보 없음';
+                      final hostText =
+                          challenge['host']?.toString() ?? '주최자 정보 없음';
 
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 20),
@@ -195,16 +196,6 @@ class _ChallengeAllScreen extends State<ChallengeAllScreen> {
                         },
                       ),
                       const SizedBox(width: 8),
-
-                      // 카테고리 드롭다운
-                      ChallengeCategoryButton(
-                        selectedCategory: _category,
-                        onCategoryChanged: (category) {
-                          setState(() {
-                            _category = category;
-                          });
-                        },
-                      ),
                     ],
                   ),
 
@@ -216,7 +207,8 @@ class _ChallengeAllScreen extends State<ChallengeAllScreen> {
                       final categoryType = _parseCategoryType(
                         challenge['category'],
                       );
-                      final hostText = challenge['host']?.toString() ?? '주최자 정보 없음';
+                      final hostText =
+                          challenge['host']?.toString() ?? '주최자 정보 없음';
 
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 20),

--- a/lib/screens/challenges/challenge_detail_screen.dart
+++ b/lib/screens/challenges/challenge_detail_screen.dart
@@ -121,7 +121,6 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
     }
 
     final topPosts = (contestData!['topPosts'] as List<dynamic>?) ?? [];
-    print(topPosts);
 
     return Scaffold(
       appBar: TitleAppbar(title: '챌린지 정보', leadingType: LeadingType.close),
@@ -345,8 +344,10 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (context) =>
-                              SuggestionAllScreen(contestId: widget.contestId),
+                          builder: (context) => SuggestionAllScreen(
+                            contestId: widget.contestId,
+                            isChallenge: true,
+                          ),
                         ),
                       );
                     },
@@ -390,11 +391,12 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
                         writer: post['userId'] ?? '익명',
                         rank: index + 1,
                         onTap: () {
+                          print(post);
                           Navigator.push(
                             context,
                             MaterialPageRoute(
                               builder: (context) => SuggestionDetailScreen(
-                                postId: post['id'] ?? post['postId'] ?? 0,
+                                postId: post['id'] ?? 0,
                                 isChallenge: true,
                               ),
                             ),

--- a/lib/screens/challenges/challenge_detail_screen.dart
+++ b/lib/screens/challenges/challenge_detail_screen.dart
@@ -121,6 +121,7 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
     }
 
     final topPosts = (contestData!['topPosts'] as List<dynamic>?) ?? [];
+    print(topPosts);
 
     return Scaffold(
       appBar: TitleAppbar(title: '챌린지 정보', leadingType: LeadingType.close),
@@ -181,6 +182,7 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
                 title: contestData!['title'] ?? '제목 없음',
                 location: contestData!['host'] ?? '주최자 미상',
                 contestId: widget.contestId,
+                isChallengeDetailTile: true,
               ),
               SizedBox(
                 width: width,
@@ -376,6 +378,7 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
                             MaterialPageRoute(
                               builder: (context) => SuggestionDetailScreen(
                                 postId: post['id'] ?? post['postId'] ?? 0,
+                                isChallenge: true,
                               ),
                             ),
                           );

--- a/lib/screens/challenges/challenge_detail_screen.dart
+++ b/lib/screens/challenges/challenge_detail_screen.dart
@@ -139,26 +139,43 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
               minimumSize: const Size.fromHeight(50),
             ),
             onPressed: () async {
-              // 챌린지 참여 화면으로 이동
-              final latitude = contestData?['latitude'] as double?;
-              final longitude = contestData?['longitude'] as double?;
+              try {
+                // 챌린지 참가 API 호출
+                await _challengeService.joinContest(
+                  contestId: widget.contestId,
+                );
 
-              final result = await Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => SuggestionScreen(
-                    isContest: true,
-                    contestId: widget.contestId,
-                    latitude: latitude,
-                    longitude: longitude,
+                // 챌린지 참여 화면으로 이동
+                final latitude = contestData?['latitude'] as double?;
+                final longitude = contestData?['longitude'] as double?;
+
+                final result = await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => SuggestionScreen(
+                      isContest: true,
+                      contestId: widget.contestId,
+                      latitude: latitude,
+                      longitude: longitude,
+                    ),
                   ),
-                ),
-              );
+                );
 
-              // 게시글 작성 완료 후 돌아왔을 때 데이터 새로고침
-              if (result != null) {
-                print('✅ 게시글 작성 완료, 챌린지 데이터 새로고침');
-                _loadContestData();
+                // 게시글 작성 완료 후 돌아왔을 때 데이터 새로고침
+                if (result != null) {
+                  print('✅ 게시글 작성 완료, 챌린지 데이터 새로고침');
+                  _loadContestData();
+                }
+              } catch (e) {
+                print('❌ 챌린지 참가 실패: $e');
+                if (mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text('챌린지 참가에 실패했습니다.'),
+                      backgroundColor: Colors.red,
+                    ),
+                  );
+                }
               }
             },
             child: const Text(

--- a/lib/screens/challenges/challenge_item.dart
+++ b/lib/screens/challenges/challenge_item.dart
@@ -7,6 +7,8 @@ class ChallengeItem extends StatelessWidget {
   final String title;
   final String location;
   final int contestId;
+  final VoidCallback? onTap;
+  final bool isChallengeDetailTile;
 
   const ChallengeItem({
     super.key,
@@ -14,6 +16,8 @@ class ChallengeItem extends StatelessWidget {
     required this.title,
     required this.location,
     required this.contestId,
+    this.isChallengeDetailTile = false,
+    this.onTap,
   });
 
   @override
@@ -50,20 +54,23 @@ class ChallengeItem extends StatelessWidget {
               ],
             ),
           ),
-          IconButton(
-            icon: const Icon(Icons.chevron_right, size: 37),
-            color: const Color(0xff757575),
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => ChallengeDetailScreen(
-                    contestId: contestId,
-                  ),
+          isChallengeDetailTile
+              ? const SizedBox.shrink()
+              : IconButton(
+                  icon: const Icon(Icons.chevron_right, size: 37),
+                  color: const Color(0xff757575),
+                  onPressed:
+                      onTap ??
+                      () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) =>
+                                ChallengeDetailScreen(contestId: contestId),
+                          ),
+                        );
+                      },
                 ),
-              );
-            },
-          ),
         ],
       ),
     );
@@ -132,5 +139,5 @@ enum CategoryType {
   RESIDENCE, // 주거/생활
   COMMERCIAL, // 상권/시장
   NIGHT, // 야간/경관
-  ENVIRONMENT // 환경/지속가능
+  ENVIRONMENT, // 환경/지속가능
 }

--- a/lib/screens/imaginary_map/comment_bottom_sheet.dart
+++ b/lib/screens/imaginary_map/comment_bottom_sheet.dart
@@ -6,8 +6,13 @@ import 'package:miyo/data/services/user_service.dart';
 
 class CommentBottomSheet extends StatefulWidget {
   final int postId;
+  final bool isChallenge;
 
-  const CommentBottomSheet({super.key, required this.postId});
+  const CommentBottomSheet({
+    super.key,
+    required this.postId,
+    this.isChallenge = false,
+  });
 
   @override
   State<CommentBottomSheet> createState() => _CommentBottomSheetState();
@@ -28,7 +33,8 @@ class _CommentBottomSheetState extends State<CommentBottomSheet> {
 
   final TextEditingController _commentInputController = TextEditingController();
   final ScrollController _commentScrollController = ScrollController();
-  final DraggableScrollableController _sheetController = DraggableScrollableController();
+  final DraggableScrollableController _sheetController =
+      DraggableScrollableController();
   final FocusNode _focusNode = FocusNode();
 
   @override
@@ -71,8 +77,17 @@ class _CommentBottomSheetState extends State<CommentBottomSheet> {
     });
 
     try {
-      // getPostById를 사용하여 게시글과 댓글 정보를 함께 가져오기
-      final postData = await _postService.getPostById(postId: widget.postId);
+      final Map<String, dynamic> postData;
+
+      if (widget.isChallenge) {
+        postData = await _postService.getContestsPostById(
+          contestId: widget.postId,
+          postId: widget.postId,
+        );
+      } else {
+        // getPostById를 사용하여 게시글과 댓글 정보를 함께 가져오기
+        postData = await _postService.getPostById(postId: widget.postId);
+      }
 
       final List<dynamic> commentsFromApi = postData['comments'] ?? [];
       final List<Map<String, dynamic>> comments = [];

--- a/lib/screens/imaginary_map/imaginary_map_bottom_sheet.dart
+++ b/lib/screens/imaginary_map/imaginary_map_bottom_sheet.dart
@@ -159,6 +159,8 @@ class _ImaginaryMapBottomSheetState extends State<ImaginaryMapBottomSheet> {
         return 'empathy'; // 공감순
       case FilterType.latest:
         return 'latest'; // 최신순
+      case FilterType.distance:
+        return 'distance'; // 거리순
     }
   }
 
@@ -380,34 +382,36 @@ class _ImaginaryMapBottomSheetState extends State<ImaginaryMapBottomSheet> {
                 child: _isLoadingNearby
                     ? const Center(child: CircularProgressIndicator())
                     : _nearbyPosts.isEmpty
-                        ? const Center(
-                            child: Text(
-                              '주변에 게시글이 없습니다',
-                              style: TextStyle(color: Color(0xff61758A)),
-                            ),
-                          )
-                        : Scrollbar(
-                            controller: _suggestionScrollController,
-                            thumbVisibility: true,
-                            thickness: 3,
-                            radius: Radius.circular(2),
-                            child: ListView.separated(
-                              controller: _suggestionScrollController,
-                              padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
-                              itemCount: _nearbyPosts.length,
-                              separatorBuilder: (context, index) =>
-                                  const SizedBox(height: 16),
-                              itemBuilder: (context, index) {
-                                final post = _nearbyPosts[index];
-                                return SuggestionItem(
-                                  categoryType: _parseCategoryType(post['category']),
-                                  title: post['title'] ?? '',
-                                  writer: post['nickname'] ?? '익명',
-                                  postId: post['postId'] as int,
-                                );
-                              },
-                            ),
-                          ),
+                    ? const Center(
+                        child: Text(
+                          '주변에 게시글이 없습니다',
+                          style: TextStyle(color: Color(0xff61758A)),
+                        ),
+                      )
+                    : Scrollbar(
+                        controller: _suggestionScrollController,
+                        thumbVisibility: true,
+                        thickness: 3,
+                        radius: Radius.circular(2),
+                        child: ListView.separated(
+                          controller: _suggestionScrollController,
+                          padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
+                          itemCount: _nearbyPosts.length,
+                          separatorBuilder: (context, index) =>
+                              const SizedBox(height: 16),
+                          itemBuilder: (context, index) {
+                            final post = _nearbyPosts[index];
+                            return SuggestionItem(
+                              categoryType: _parseCategoryType(
+                                post['category'],
+                              ),
+                              title: post['title'] ?? '',
+                              writer: post['nickname'] ?? '익명',
+                              postId: post['postId'] as int,
+                            );
+                          },
+                        ),
+                      ),
               ),
             ],
           ),

--- a/lib/screens/imaginary_map/suggestion_filtering_button.dart
+++ b/lib/screens/imaginary_map/suggestion_filtering_button.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 enum FilterType {
   popularity, // 인기순
   latest, // 최신순
+  distance, // 거리순
 }
 
 class SuggestionFilteringButton extends StatelessWidget {
@@ -18,6 +19,7 @@ class SuggestionFilteringButton extends StatelessWidget {
   static const Map<FilterType, String> filterNames = {
     FilterType.popularity: '인기순',
     FilterType.latest: '최신순',
+    FilterType.distance: '거리순',
   };
 
   @override
@@ -30,6 +32,7 @@ class SuggestionFilteringButton extends StatelessWidget {
       itemBuilder: (context) => [
         _buildMenuItem(FilterType.popularity),
         _buildMenuItem(FilterType.latest),
+        _buildMenuItem(FilterType.distance),
       ],
       child: Container(
         // 필터링 버튼

--- a/lib/screens/imaginary_map/suggestion_item.dart
+++ b/lib/screens/imaginary_map/suggestion_item.dart
@@ -6,6 +6,7 @@ class SuggestionItem extends StatelessWidget {
   final String title;
   final String writer;
   final int postId;
+  final bool isChallenge;
 
   const SuggestionItem({
     super.key,
@@ -13,6 +14,7 @@ class SuggestionItem extends StatelessWidget {
     required this.title,
     required this.writer,
     required this.postId,
+    this.isChallenge = false,
   });
 
   @override
@@ -56,7 +58,10 @@ class SuggestionItem extends StatelessWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => SuggestionDetailScreen(postId: postId),
+                  builder: (context) => SuggestionDetailScreen(
+                    postId: postId,
+                    isChallenge: isChallenge,
+                  ),
                 ),
               );
             },

--- a/lib/screens/suggestion/suggestion_all_screen.dart
+++ b/lib/screens/suggestion/suggestion_all_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:miyo/components/title_appbar.dart';
 import 'package:miyo/screens/imaginary_map/suggestion_item.dart';
 import 'package:miyo/screens/imaginary_map/suggestion_filtering_button.dart';
+import 'package:miyo/components/challenge_filtering_button.dart';
 import 'package:miyo/data/services/suggestion_service.dart';
 
 class SuggestionAllScreen extends StatefulWidget {
@@ -21,6 +22,7 @@ class SuggestionAllScreen extends StatefulWidget {
 class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
   final SuggestionService _suggestionService = SuggestionService();
   FilterType _sortBy = FilterType.latest;
+  ChallengeCategoryType _category = ChallengeCategoryType.all;
 
   List<dynamic> _allSuggestions = [];
   bool _isLoading = true;
@@ -179,8 +181,8 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
 
                   // 필터 드롭다운
                   Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      // 정렬 드롭다운
                       SuggestionFilteringButton(
                         selectedFilter: _sortBy,
                         onFilterChanged: (filter) {
@@ -188,6 +190,14 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                             _sortBy = filter;
                           });
                           _loadSuggestions();
+                        },
+                      ),
+                      ChallengeCategoryButton(
+                        selectedCategory: _category,
+                        onCategoryChanged: (category) {
+                          setState(() {
+                            _category = category;
+                          });
                         },
                       ),
                     ],

--- a/lib/screens/suggestion/suggestion_all_screen.dart
+++ b/lib/screens/suggestion/suggestion_all_screen.dart
@@ -6,8 +6,13 @@ import 'package:miyo/data/services/suggestion_service.dart';
 
 class SuggestionAllScreen extends StatefulWidget {
   final int contestId;
+  final bool isChallenge;
 
-  const SuggestionAllScreen({super.key, required this.contestId});
+  const SuggestionAllScreen({
+    super.key,
+    required this.contestId,
+    this.isChallenge = false,
+  });
 
   @override
   State<SuggestionAllScreen> createState() => _SuggestionAllScreenState();
@@ -157,7 +162,10 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                           title: suggestion['title']?.toString() ?? '제목 없음',
                           writer:
                               suggestion['userId']?.toString() ?? '작성자 정보 없음',
-                          postId: suggestion['postId'] ?? 0,
+                          postId: widget.isChallenge
+                              ? suggestion['id']
+                              : suggestion['postId'] ?? 0,
+                          isChallenge: widget.isChallenge,
                         ),
                       );
                     })
@@ -199,7 +207,10 @@ class _SuggestionAllScreenState extends State<SuggestionAllScreen> {
                           title: suggestion['title']?.toString() ?? '제목 없음',
                           writer:
                               suggestion['userId']?.toString() ?? '작성자 정보 없음',
-                          postId: suggestion['postId'] ?? 0,
+                          postId: widget.isChallenge
+                              ? suggestion['id']
+                              : suggestion['postId'] ?? 0,
+                          isChallenge: widget.isChallenge,
                         ),
                       );
                     })

--- a/lib/screens/suggestion/suggestion_detail_screen.dart
+++ b/lib/screens/suggestion/suggestion_detail_screen.dart
@@ -5,7 +5,7 @@ import 'package:miyo/data/services/post_service.dart';
 
 class SuggestionDetailScreen extends StatefulWidget {
   final int postId;
-  final isChallenge;
+  final bool isChallenge;
 
   const SuggestionDetailScreen({
     super.key,

--- a/lib/screens/suggestion/suggestion_detail_screen.dart
+++ b/lib/screens/suggestion/suggestion_detail_screen.dart
@@ -37,6 +37,7 @@ class _SuggestionDetailScreenState extends State<SuggestionDetailScreen> {
       if (widget.isChallenge) {
         final data = await _postService.getContestsPostById(
           contestId: widget.postId,
+          postId: widget.postId,
         );
         print('📦 게시글 데이터: $data');
         print(
@@ -77,16 +78,16 @@ class _SuggestionDetailScreenState extends State<SuggestionDetailScreen> {
     if (postData == null) return;
 
     // 이전 상태 저장
-    final previousIsEmpathized = postData!['isEmpathized'];
-    final previousCount = postData!['empathyCount'];
+    final previousIsEmpathized = postData!['isEmpathized'] ?? false;
+    final previousCount = postData!['empathyCount'] ?? 0;
 
     setState(() {
-      if (postData!['isEmpathized']) {
+      if (postData!['isEmpathized'] ?? false) {
         postData!['isEmpathized'] = false;
-        postData!['empathyCount']--;
+        postData!['empathyCount'] = (postData!['empathyCount'] ?? 0) - 1;
       } else {
         postData!['isEmpathized'] = true;
-        postData!['empathyCount']++;
+        postData!['empathyCount'] = (postData!['empathyCount'] ?? 0) + 1;
       }
     });
 
@@ -193,10 +194,10 @@ class _SuggestionDetailScreenState extends State<SuggestionDetailScreen> {
               GestureDetector(
                 onTap: toggleEmpathy,
                 child: Icon(
-                  postData!['isEmpathized']
+                  (postData!['isEmpathized'] ?? false)
                       ? Icons.favorite
                       : Icons.favorite_border,
-                  color: postData!['isEmpathized']
+                  color: (postData!['isEmpathized'] ?? false)
                       ? Colors.red
                       : Color(0xff61758A),
                   size: 24,
@@ -206,7 +207,7 @@ class _SuggestionDetailScreenState extends State<SuggestionDetailScreen> {
               GestureDetector(
                 onTap: toggleEmpathy,
                 child: Text(
-                  '${postData!['empathyCount']}',
+                  '${postData!['empathyCount'] ?? 0}',
                   style: TextStyle(
                     fontSize: 20,
                     fontWeight: FontWeight.w700,
@@ -230,8 +231,10 @@ class _SuggestionDetailScreenState extends State<SuggestionDetailScreen> {
                       context: context,
                       isScrollControlled: true,
                       backgroundColor: Colors.transparent,
-                      builder: (context) =>
-                          CommentBottomSheet(postId: widget.postId),
+                      builder: (context) => CommentBottomSheet(
+                        postId: widget.postId,
+                        isChallenge: true,
+                      ),
                     );
                   },
                   child: Text(
@@ -294,7 +297,7 @@ class _SuggestionDetailScreenState extends State<SuggestionDetailScreen> {
               Row(
                 children: [
                   Text(
-                    postData!['nickname'] ?? '익명',
+                    postData!['userNickname'] ?? '익명',
                     style: TextStyle(
                       fontSize: 14,
                       fontWeight: FontWeight.w500,

--- a/lib/screens/suggestion/suggestion_detail_screen.dart
+++ b/lib/screens/suggestion/suggestion_detail_screen.dart
@@ -5,8 +5,13 @@ import 'package:miyo/data/services/post_service.dart';
 
 class SuggestionDetailScreen extends StatefulWidget {
   final int postId;
+  final isChallenge;
 
-  const SuggestionDetailScreen({super.key, required this.postId});
+  const SuggestionDetailScreen({
+    super.key,
+    required this.postId,
+    this.isChallenge = false,
+  });
 
   @override
   State<SuggestionDetailScreen> createState() => _SuggestionDetailScreenState();
@@ -29,15 +34,29 @@ class _SuggestionDetailScreenState extends State<SuggestionDetailScreen> {
     });
 
     try {
-      final data = await _postService.getPostById(postId: widget.postId);
-      print('📦 게시글 데이터: $data');
-      print(
-        '👤 작성자 정보: ${data['nickname']} / ${data['userNickname']} / ${data['author']}',
-      );
-      setState(() {
-        postData = data;
-        isLoading = false;
-      });
+      if (widget.isChallenge) {
+        final data = await _postService.getContestsPostById(
+          contestId: widget.postId,
+        );
+        print('📦 게시글 데이터: $data');
+        print(
+          '👤 작성자 정보: ${data['nickname']} / ${data['userNickname']} / ${data['author']}',
+        );
+        setState(() {
+          postData = data;
+          isLoading = false;
+        });
+      } else {
+        final data = await _postService.getPostById(postId: widget.postId);
+        print('📦 게시글 데이터: $data');
+        print(
+          '👤 작성자 정보: ${data['nickname']} / ${data['userNickname']} / ${data['author']}',
+        );
+        setState(() {
+          postData = data;
+          isLoading = false;
+        });
+      }
     } catch (e) {
       print('❌ 게시글 로드 실패: $e');
       if (mounted) {


### PR DESCRIPTION
## 📝작업 내용
( #50 )
- 챌린지 내 제안글 & 기본 제안글 로직 분리
- 챌린지 내 제안글 api 구현

( #9 )
- 삭제된 정렬 기능 복원
- 정렬 버튼 디자인 통일

## 💬리뷰 요구사항